### PR TITLE
Add rbac annotations to ContainerSource controller

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -95,6 +95,14 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - sources.eventing.knative.dev
   resources:
   - containersources
@@ -106,14 +114,6 @@ rules:
   - update
   - patch
   - delete
-- apiGroups:
-  - serving.knative.dev
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -17,6 +17,14 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - sources.eventing.knative.dev
   resources:
   - containersources
@@ -28,11 +36,3 @@ rules:
   - update
   - patch
   - delete
-- apiGroups:
-  - serving.knative.dev
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch

--- a/pkg/controller/containersource/doc.go
+++ b/pkg/controller/containersource/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package containersource implements the ContainerSource controller.
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=serving.knative.dev,resources=services,verbs=get;list;watch
+// +kubebuilder:rbac:groups=sources.eventing.knative.dev,resources=containersources,verbs=get;list;watch;create;update;patch;delete
+package containersource


### PR DESCRIPTION
Currently ContainerSource controller needs to have full permissions on Deployment and ContainerSource resources. It also needs to read (get, list, watch) Sinkable resources. The default added here is Knative Services.

Also ran `hack/update-codegen.sh && hack/update-manifests.sh` to update the generated yaml files.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
