### PR TITLE
Found that we were calling to dep ensure, call the hack script instead.

### DIFF
--- a/hack/update-manifests.sh
+++ b/hack/update-manifests.sh
@@ -23,7 +23,7 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
 cd ${REPO_ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
-dep ensure
+${REPO_ROOT_DIR}/hack/update-deps.sh
 
 # Generate manifests e.g. CRD, RBAC etc.
 go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all


### PR DESCRIPTION
## Proposed Changes

  * Generate manifests was leaving extra junk... use the correct command.

**Release Note**
```release-note
NONE
```