### PR TITLE
Integrate k8s events

### DIFF
--- a/config/crds/sources_v1alpha1_kuberneteseventsource.yaml
+++ b/config/crds/sources_v1alpha1_kuberneteseventsource.yaml
@@ -22,8 +22,12 @@ spec:
           type: object
         spec:
           properties:
+            namespace:
+              type: string
             sink:
               type: object
+          required:
+          - namespace
           type: object
         status:
           properties:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -100,8 +100,12 @@ spec:
           type: object
         spec:
           properties:
+            namespace:
+              type: string
             sink:
               type: object
+          required:
+          - namespace
           type: object
         status:
           properties:

--- a/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go
+++ b/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go
@@ -32,6 +32,9 @@ var _ = duck.VerifyType(&KubernetesEventSource{}, &duckv1alpha1.Conditions{})
 
 // KubernetesEventSourceSpec defines the desired state of the source.
 type KubernetesEventSourceSpec struct {
+	// Namespace that we watch kubernetes events in.
+	Namespace string `json:"namespace"`
+
 	// Sink is a reference to an object that will resolve to a domain name to use
 	// as the sink.
 	// +optional

--- a/pkg/controller/kuberneteseventsource/resources/containersource.go
+++ b/pkg/controller/kuberneteseventsource/resources/containersource.go
@@ -33,6 +33,7 @@ func MakeContainerSource(source *sourcesv1alpha1.KubernetesEventSource, receiveA
 		},
 		Spec: sourcesv1alpha1.ContainerSourceSpec{
 			Image: receiveAdapterImage,
+			Args:  []string{fmt.Sprintf("--namespace=%s", source.Spec.Namespace)},
 			Sink:  source.Spec.Sink,
 		},
 	}


### PR DESCRIPTION
Addresses #446

## Proposed Changes

  * Use flags instead of env variables
  * change kuberneteseventsource.spec to take in a namespace to watch
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
k8s events sources now work with following very big caveats:
  - need to give default service account permissions to watch events
  - it must be default service account because no way to specify that
  - need to modify virtual services and k8s services
```