### PR TITLE
K8s source controller updates

### DIFF
--- a/config/samples/sources_v1alpha1_kuberneteseventsource.yaml
+++ b/config/samples/sources_v1alpha1_kuberneteseventsource.yaml
@@ -8,4 +8,47 @@ spec:
   sink:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: Channel
-    name: foo-channel
+    name: k8ssource
+    
+---
+  
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Channel
+metadata:
+  name: k8ssource
+spec:
+  provisioner:
+    name: in-memory-channel
+    
+---
+  
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: event-watcher
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  
+---
+  
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: k8s-ra-event-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: event-watcher
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default

--- a/pkg/controller/kuberneteseventsource/reconcile.go
+++ b/pkg/controller/kuberneteseventsource/reconcile.go
@@ -114,6 +114,15 @@ func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.Kube
 		}
 	}
 
+	// Update ContainerSource spec if it's changed
+	expected := resources.MakeContainerSource(source, r.receiveAdapterImage)
+	if !equality.Semantic.DeepEqual(cs.Spec, expected.Spec) {
+		cs.Spec = expected.Spec
+		if r.Update(ctx, cs); err != nil {
+			return err
+		}
+	}
+
 	// Copy ContainerSource conditions to source
 	source.Status.Conditions = cs.Status.Conditions.DeepCopy()
 	return nil

--- a/pkg/controller/kuberneteseventsource/reconcile.go
+++ b/pkg/controller/kuberneteseventsource/reconcile.go
@@ -114,18 +114,8 @@ func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.Kube
 		}
 	}
 
-	if cs.Status.IsReady() {
-		source.Status.MarkReady()
-	} else {
-		reason := ""
-		message := ""
-		if ready := cs.Status.GetCondition(sourcesv1alpha1.ContainerConditionReady); ready != nil {
-			reason = ready.Reason
-			message = ready.Message
-		}
-		source.Status.MarkUnready(reason, message)
-	}
-
+	// Copy ContainerSource conditions to source
+	source.Status.Conditions = cs.Status.Conditions.DeepCopy()
 	return nil
 }
 


### PR DESCRIPTION
## Proposed Changes

  * **Copy KES-owned ContainerSource conditions to KES.** This makes the status of the KES more obvious by hoisting every condition from the ContainerSource.
  * **Update the ContainerSource spec if needed.** If the Spec of the KES changes, the ContainerSource needs to be updated too. Use DeepEqual to only update when necessary.
  * **Add additional objects required for KES sample.** The KES sample also needs a channel and RBAC to read events. A future PR should allow the KES to take a service account to pass through to the
receive adapter pod.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```