### PR TITLE
ContainerSource updates

### DIFF
--- a/config/crds/sources_v1alpha1_containersource.yaml
+++ b/config/crds/sources_v1alpha1_containersource.yaml
@@ -31,6 +31,10 @@ spec:
               items:
                 type: string
               type: array
+            env:
+              items:
+                type: object
+              type: array
             image:
               minLength: 1
               type: string

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -38,6 +38,10 @@ spec:
               items:
                 type: string
               type: array
+            env:
+              items:
+                type: object
+              type: array
             image:
               minLength: 1
               type: string

--- a/pkg/apis/sources/v1alpha1/containersource_types.go
+++ b/pkg/apis/sources/v1alpha1/containersource_types.go
@@ -42,6 +42,13 @@ type ContainerSourceSpec struct {
 	// Args are passed to the ContainerSpec as they are.
 	Args []string `json:"args,omitempty"`
 
+	// Env is the list of environment variables to set in the container.
+	// Cannot be updated.
+	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Env []corev1.EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+
 	// Sink is a reference to an object that will resolve to a domain name to use as the sink.
 	// +optional
 	Sink *corev1.ObjectReference `json:"sink,omitempty"`

--- a/pkg/apis/sources/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/sources/v1alpha1/zz_generated.deepcopy.go
@@ -95,6 +95,13 @@ func (in *ContainerSourceSpec) DeepCopyInto(out *ContainerSourceSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Sink != nil {
 		in, out := &in.Sink, &out.Sink
 		*out = new(v1.ObjectReference)

--- a/pkg/controller/containersource/reconcile.go
+++ b/pkg/controller/containersource/reconcile.go
@@ -79,6 +79,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 		Namespace: source.Namespace,
 		Image:     source.Spec.Image,
 		Args:      source.Spec.Args,
+		Env:       source.Spec.Env,
 	}
 
 	err = r.setSinkURIArg(source, args)

--- a/pkg/controller/containersource/resources/arguments.go
+++ b/pkg/controller/containersource/resources/arguments.go
@@ -16,11 +16,16 @@ limitations under the License.
 
 package resources
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
 type ContainerArguments struct {
 	Name       string
 	Namespace  string
 	Image      string
 	Args       []string
+	Env        []corev1.EnvVar
 	SinkInArgs bool
 	Sink       string
 }

--- a/pkg/controller/containersource/resources/deployment.go
+++ b/pkg/controller/containersource/resources/deployment.go
@@ -35,6 +35,8 @@ func MakeDeployment(org *appsv1.Deployment, args *ContainerArguments) *appsv1.De
 		containerArgs = append(containerArgs, remote)
 	}
 
+	env := append(args.Env, corev1.EnvVar{Name: "SINK", Value: args.Sink})
+
 	deploy := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -63,6 +65,7 @@ func MakeDeployment(org *appsv1.Deployment, args *ContainerArguments) *appsv1.De
 							Name:            "source",
 							Image:           args.Image,
 							Args:            containerArgs,
+							Env:             env,
 							ImagePullPolicy: corev1.PullAlways,
 						},
 					},

--- a/pkg/controller/containersource/resources/deployment.go
+++ b/pkg/controller/containersource/resources/deployment.go
@@ -55,6 +55,9 @@ func MakeDeployment(org *appsv1.Deployment, args *ContainerArguments) *appsv1.De
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "true",
+					},
 					Labels: map[string]string{
 						"source": args.Name,
 					},


### PR DESCRIPTION
## Proposed Changes

  * **Allow passing env vars to container source.** Every container source gets a `SINK` env var populated with the sink uri.
  * **Inject the istio sidecar into container sources.** Every container source needs to talk to a channel, so every container source needs the istio sidecar.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Allow passing env vars to container sources
Inject the istio sidecar into container sources
```