### PR TITLE
Define release yamls

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -26,7 +26,8 @@ readonly EVENTING_SOURCES_RELEASE_GCR
 
 # Yaml files to generate, and the source config dir for them.
 declare -A RELEASES
-RELEASES["release.yaml"]="config"
+RELEASES["release-without-gcppubsub.yaml"]="config/default.yaml"
+RELEASES["release-with-gcppubsub"]="config/default-gcppubsub.yaml"
 readonly RELEASES
 
 # Script entry point.

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -27,7 +27,7 @@ readonly EVENTING_SOURCES_RELEASE_GCR
 # Yaml files to generate, and the source config dir for them.
 declare -A RELEASES
 RELEASES["release-without-gcppubsub.yaml"]="config/default.yaml"
-RELEASES["release-with-gcppubsub"]="config/default-gcppubsub.yaml"
+RELEASES["release-with-gcppubsub.yaml"]="config/default-gcppubsub.yaml"
 readonly RELEASES
 
 # Script entry point.
@@ -56,7 +56,7 @@ all_yamls=()
 for yaml in "${!RELEASES[@]}"; do
   config="${RELEASES[${yaml}]}"
   echo "Building Knative Eventing Sources - ${config}"
-  ko resolve ${KO_FLAGS} -f ${config}/ > ${yaml}
+  ko resolve ${KO_FLAGS} -f ${config} > ${yaml}
   tag_images_in_yaml ${yaml} ${EVENTING_SOURCES_RELEASE_GCR} ${TAG}
   all_yamls+=(${yaml})
 done


### PR DESCRIPTION
For now there is `release-without-gcppubsub.yaml` and `release-with-gcppubsub.yaml` corresponding to `config/default.yaml` and `config/default-gcppubsub.yaml`. Release names TBD :smile:

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Release some releases
```

/cc @evankanderson 