### PR TITLE
Fix ko urls in gcppubsub config

### DIFF
--- a/config/default-gcppubsub.yaml
+++ b/config/default-gcppubsub.yaml
@@ -392,8 +392,8 @@ spec:
         - name: GCPPUBSUB_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/gcppubsub_receive_adapter
         - name: K8S_RA_IMAGE
-          value: github.com/knative/eventing-sources/cmd/kuberneteseventsource/
-        image: github.com/knative/eventing-sources/cmd/manager/
+          value: github.com/knative/eventing-sources/cmd/kuberneteseventsource
+        image: github.com/knative/eventing-sources/cmd/manager
         name: manager
         resources:
           limits:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -314,8 +314,8 @@ spec:
       containers:
       - env:
         - name: K8S_RA_IMAGE
-          value: github.com/knative/eventing-sources/cmd/kuberneteseventsource/
-        image: github.com/knative/eventing-sources/cmd/manager/
+          value: github.com/knative/eventing-sources/cmd/kuberneteseventsource
+        image: github.com/knative/eventing-sources/cmd/manager
         name: manager
         resources:
           limits:

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -6,8 +6,8 @@ spec:
   template:
     spec:
       containers:
-      - image: github.com/knative/eventing-sources/cmd/manager/
+      - image: github.com/knative/eventing-sources/cmd/manager
         name: manager
         env:
         - name: K8S_RA_IMAGE
-          value: github.com/knative/eventing-sources/cmd/kuberneteseventsource/
+          value: github.com/knative/eventing-sources/cmd/kuberneteseventsource


### PR DESCRIPTION
The trailing slash confuses ko and/or go get, generating an invalid resource name error:

```
W1103 09:33:53.746] 2018/11/03 09:33:53 error processing import paths in "config/default-gcppubsub.yaml": no token in bearer response:
W1103 09:33:53.746] {"errors":[{"code":"NAME_INVALID","message":"Invalid resource name: \"repository:knative-releases/github.com/knative/eventing-sources/cmd/kuberneteseventsource/:push,pull\", must match: \"[a-z0-9._-]+(?:/[a-z0-9._-]+)*\""}]}
W1103 09:33:53.767] Run: ('/workspace/./test-infra/jenkins/../scenarios/../hack/coalesce.py',)
```

Fixes #67.

/cc @adamharwayne @adrcunha 