### PR TITLE
Add a release.yaml default release

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -26,6 +26,7 @@ readonly EVENTING_SOURCES_RELEASE_GCR
 
 # Yaml files to generate, and the source config dir for them.
 declare -A RELEASES
+RELEASES["release.yaml"]="config/default.yaml"
 RELEASES["release-without-gcppubsub.yaml"]="config/default.yaml"
 RELEASES["release-with-gcppubsub.yaml"]="config/default-gcppubsub.yaml"
 readonly RELEASES

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -27,7 +27,6 @@ readonly EVENTING_SOURCES_RELEASE_GCR
 # Yaml files to generate, and the source config dir for them.
 declare -A RELEASES
 RELEASES["release.yaml"]="config/default.yaml"
-RELEASES["release-without-gcppubsub.yaml"]="config/default.yaml"
 RELEASES["release-with-gcppubsub.yaml"]="config/default-gcppubsub.yaml"
 readonly RELEASES
 


### PR DESCRIPTION
Identical to `release-without-gcppubsub.yaml`, so now there are three variants:

- `release.yaml`
- `release-without-gcppubsub.yaml` (identical to `release.yaml`)
- `release-with-gcppubsub.yaml`

I don't have a strong opinion about `release-without-gcppubsub.yaml`. It seems like it might be useful, but it might just be confusing. We'll have a different release structure anyway once we break sources out into their own repos.

/cc @evankanderson @vaikas-google 