### PR TITLE
Update Deployment spec on ContainerSource change

### DIFF
--- a/pkg/controller/containersource/reconcile.go
+++ b/pkg/controller/containersource/reconcile.go
@@ -99,7 +99,9 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 			}
 			r.recorder.Eventf(source, corev1.EventTypeNormal, "Deployed", "Created deployment %q", deploy.Name)
 			source.Status.MarkDeploying("Deploying", "Created deployment %s", args.Name)
-			// Wait for the deployment to get a status
+			// Since the Deployment has just been created, there's nothing more
+			// to do until it gets a status. This ContainerSource will be reconciled
+			// again when the Deployment is updated.
 			return object, nil
 		}
 		return object, err


### PR DESCRIPTION
Without this the ContainerSource never reconciles the Deployment. Tests will be coming soon in a different PR.

## Proposed Changes

  * Update Deployment owned by a ContainerSource when the ContainerSource spec changes.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
ContainerSource updates owned Deployment when spec changes.
```

/cc @n3wscott @vaikas-google 