### PR TITLE
Test MakeContainerSource

### DIFF
--- a/pkg/controller/kuberneteseventsource/resources/containersource_test.go
+++ b/pkg/controller/kuberneteseventsource/resources/containersource_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	sourcesv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMakeContainerSource(t *testing.T) {
+	kes := &sourcesv1alpha1.KubernetesEventSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kes",
+			Namespace: "ns",
+		},
+		Spec: sourcesv1alpha1.KubernetesEventSourceSpec{
+			ServiceAccountName: "serviceaccount",
+			Namespace:          "watchns",
+			Sink: &corev1.ObjectReference{
+				Name:      "sink",
+				Namespace: "sinkns",
+			},
+		},
+	}
+
+	got := MakeContainerSource(kes, "raimage")
+	want := &sourcesv1alpha1.ContainerSource{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "kes-",
+			Namespace:    "ns",
+		},
+		Spec: sourcesv1alpha1.ContainerSourceSpec{
+			Image:              "raimage",
+			Args:               []string{"--namespace=watchns"},
+			ServiceAccountName: "serviceaccount",
+			Sink: &corev1.ObjectReference{
+				Name:      "sink",
+				Namespace: "sinkns",
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Unexpected difference: (-want, +got): %v", diff)
+	}
+
+}

--- a/pkg/controller/kuberneteseventsource/resources/containersource_test.go
+++ b/pkg/controller/kuberneteseventsource/resources/containersource_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestMakeContainerSource(t *testing.T) {
-	kes := &sourcesv1alpha1.KubernetesEventSource{
+	got := MakeContainerSource(&sourcesv1alpha1.KubernetesEventSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kes",
 			Namespace: "ns",
@@ -39,9 +39,8 @@ func TestMakeContainerSource(t *testing.T) {
 				Namespace: "sinkns",
 			},
 		},
-	}
+	}, "raimage")
 
-	got := MakeContainerSource(kes, "raimage")
 	want := &sourcesv1alpha1.ContainerSource{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "kes-",


### PR DESCRIPTION
Adds a test for `pkg/controller/kuberneteseventsource/resources.MakeContainerSource`.

The example used for the test is constructed using literal values only, forcing me to be explicit about the expected value of the computed result. I think this avoids the issue you're worried about in https://github.com/knative/eventing-sources/pull/88#discussion_r232077055.

While composing the example, I asked this question for each field: **Is the value of this field determined by the parameters passed in to the function?** If the answer is yes, then that field should be compared, otherwise it should be ignored.

In this case, the answer for every field was yes, so there were no ignores.

/cc @n3wscott @evankanderson 