### PR TITLE
Only try to print out the subscription if it has been created successfully

### DIFF
--- a/pkg/controller/gcppubsub/reconcile.go
+++ b/pkg/controller/gcppubsub/reconcile.go
@@ -230,7 +230,11 @@ func (r *reconciler) createSubscription(ctx context.Context, src *v1alpha1.GcpPu
 	createdSub, err := psc.CreateSubscription(ctx, sub.ID(), pubsub.SubscriptionConfig{
 		Topic: psc.Topic(src.Spec.Topic),
 	})
-	logging.FromContext(ctx).Desugar().Info("Created new subscription", zap.Error(err), zap.Any("subscription", createdSub))
+	if err != nil {
+		logging.FromContext(ctx).Desugar().Info("Error creating new subscription", zap.Error(err))
+	} else {
+		logging.FromContext(ctx).Desugar().Info("Created new subscription", zap.Any("subscription", createdSub))
+	}
 	return createdSub, err
 }
 


### PR DESCRIPTION
## Proposed Changes

  * Only try to print out the `subscription` if it has been created successfully. 
        - If the `subscription` is nil, then logging it will panic.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```