### PR TITLE
Print the string instead of the pointer

### DIFF
--- a/cmd/githubsource/main.go
+++ b/cmd/githubsource/main.go
@@ -54,7 +54,7 @@ func main() {
 		log.Fatalf("No secret token given")
 	}
 
-	log.Printf("Sink is: %q", sink)
+	log.Printf("Sink is: %q", *sink)
 
 	ra := &githubsource.GitHubReceiveAdapter{
 		Sink: *sink,


### PR DESCRIPTION
Fixes a compile error complaining about using a string directive on a pointer:

```
cmd/githubsource/main.go:57: Printf format %q has arg sink of wrong type *string 
```

I'm not sure why this doesn't come up in builds. Maybe it's specific to my go version?

```
$ go version             
go version go1.11 linux/amd64
```

/cc @bbrowning