### PR TITLE
Exclude code in testing/ dirs from coverage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,6 @@
 # coverage-excluded is an attribute used to explicitly exclude a path from being included in code
 # coverage. If a path is marked as linguist-generated already, it will be implicitly excluded and
 # there is no need to add the coverage-excluded attribute
-#/pkg/controller/testing/** coverage-excluded=true
+/pkg/**/testing/** coverage-excluded=true
 /vendor/** coverage-excluded=true
 /test/** coverage-excluded=true


### PR DESCRIPTION
Mirrors the exclusion in knative/serving (which was last updated in https://github.com/knative/serving/pull/1779).

See https://github.com/knative/eventing/issues/591. 

## Proposed Changes

  * Exclude `pkg/**/testing/**` from coverage. Current includes `pkg/controller/testing/mock_client.go` and `pkg/controller/testing/table.go`.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```