### PR TITLE
Use DeepDerivative instead of DeepEqual

### DIFF
--- a/pkg/controller/containersource/reconcile.go
+++ b/pkg/controller/containersource/reconcile.go
@@ -109,7 +109,10 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 
 	// Update Deployment spec if it's changed
 	expected := resources.MakeDeployment(nil, args)
-	if !equality.Semantic.DeepEqual(deploy.Spec, expected.Spec) {
+	// Since the Deployment spec has fields defaulted by the webhook, it won't
+	// be equal to expected. Use DeepDerivative to compare only the fields that
+	// are set in expected.
+	if !equality.Semantic.DeepDerivative(expected.Spec, deploy.Spec) {
 		deploy.Spec = expected.Spec
 		err := r.client.Update(ctx, deploy)
 		// if no error, update the status.


### PR DESCRIPTION
Since the Deployment spec has fields defaulted by the webhook, it won't be equal to expected. Use [`DeepDerivative`](https://github.com/kubernetes/apimachinery/blob/2a7c9300402896b3c073f2f47df85527c94f83a0/third_party/forked/golang/reflect/deep_equal.go#L378) to compare only the fields that are set in expected.

Because this always attempted to update the deployment, the source status could never progress to ready.

/cc @Harwayne 