### PR TITLE
[WIP] Default KubernetesEventSource namespace

### DIFF
--- a/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go
+++ b/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go
@@ -32,7 +32,9 @@ var _ = duck.VerifyType(&KubernetesEventSource{}, &duckv1alpha1.Conditions{})
 
 // KubernetesEventSourceSpec defines the desired state of the source.
 type KubernetesEventSourceSpec struct {
-	// Namespace that we watch kubernetes events in.
+	// Namespace that we watch kubernetes events in. Defaults to the namespace
+	// of the source.
+	// +optional
 	Namespace string `json:"namespace"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run this

--- a/pkg/controller/kuberneteseventsource/resources/containersource.go
+++ b/pkg/controller/kuberneteseventsource/resources/containersource.go
@@ -26,6 +26,11 @@ import (
 // MakeContainerSource generates, but does not create, a ContainerSource for the
 // given KubernetesEventSource.
 func MakeContainerSource(source *sourcesv1alpha1.KubernetesEventSource, receiveAdapterImage string) *sourcesv1alpha1.ContainerSource {
+	namespace := source.Spec.Namespace
+	if namespace == "" {
+		namespace = source.Namespace
+	}
+
 	return &sourcesv1alpha1.ContainerSource{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", source.Name),
@@ -33,7 +38,7 @@ func MakeContainerSource(source *sourcesv1alpha1.KubernetesEventSource, receiveA
 		},
 		Spec: sourcesv1alpha1.ContainerSourceSpec{
 			Image:              receiveAdapterImage,
-			Args:               []string{fmt.Sprintf("--namespace=%s", source.Spec.Namespace)},
+			Args:               []string{fmt.Sprintf("--namespace=%s", namespace)},
 			ServiceAccountName: source.Spec.ServiceAccountName,
 			Sink:               source.Spec.Sink,
 		},


### PR DESCRIPTION
If the Namespace field is empty, default to the same namespace as the source.

This is WIP because I'd like to get unit tests for KES in first.

## Proposed Changes

  * Default KubernetesEventSource watched namespace to same namespace as source

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
KubernetesEventSource will now watch events in the same namespace as the source by default.
```

/cc @vaikas-google 