### PR TITLE
Use Status subresource

### DIFF
--- a/config/crds/sources_v1alpha1_containersource.yaml
+++ b/config/crds/sources_v1alpha1_containersource.yaml
@@ -16,6 +16,8 @@ spec:
     kind: ContainerSource
     plural: containersources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/config/crds/sources_v1alpha1_gcppubsubsource.yaml
+++ b/config/crds/sources_v1alpha1_gcppubsubsource.yaml
@@ -16,6 +16,8 @@ spec:
     kind: GcpPubSubSource
     plural: gcppubsubsources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/config/crds/sources_v1alpha1_githubsource.yaml
+++ b/config/crds/sources_v1alpha1_githubsource.yaml
@@ -16,6 +16,8 @@ spec:
     kind: GitHubSource
     plural: githubsources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/config/crds/sources_v1alpha1_kuberneteseventsource.yaml
+++ b/config/crds/sources_v1alpha1_kuberneteseventsource.yaml
@@ -16,6 +16,8 @@ spec:
     kind: KubernetesEventSource
     plural: kuberneteseventsources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/config/default-gcppubsub.yaml
+++ b/config/default-gcppubsub.yaml
@@ -23,6 +23,8 @@ spec:
     kind: ContainerSource
     plural: containersources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -100,6 +102,8 @@ spec:
     kind: GcpPubSubSource
     plural: gcppubsubsources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -172,6 +176,8 @@ spec:
     kind: GitHubSource
     plural: githubsources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -297,6 +303,8 @@ spec:
     kind: KubernetesEventSource
     plural: kuberneteseventsources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -23,6 +23,8 @@ spec:
     kind: ContainerSource
     plural: containersources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -100,6 +102,8 @@ spec:
     kind: GitHubSource
     plural: githubsources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -225,6 +229,8 @@ spec:
     kind: KubernetesEventSource
     plural: kuberneteseventsources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/pkg/apis/sources/v1alpha1/containersource_types.go
+++ b/pkg/apis/sources/v1alpha1/containersource_types.go
@@ -137,6 +137,7 @@ func (s *ContainerSourceStatus) MarkNotDeployed(reason, messageFormat string, me
 
 // ContainerSource is the Schema for the containersources API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:categories=all,knative,eventing,sources
 type ContainerSource struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go
+++ b/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go
@@ -30,6 +30,7 @@ import (
 
 // GcpPubSubSource is the Schema for the gcppubsubsources API.
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:categories=all,knative,eventing,sources
 type GcpPubSubSource struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/sources/v1alpha1/githubsource_types.go
+++ b/pkg/apis/sources/v1alpha1/githubsource_types.go
@@ -164,6 +164,7 @@ func (s *GitHubSourceStatus) MarkNoSink(reason, messageFormat string, messageA .
 
 // GitHubSource is the Schema for the githubsources API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:categories=all,knative,eventing,sources
 type GitHubSource struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go
+++ b/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go
@@ -99,6 +99,7 @@ func (s *KubernetesEventSourceStatus) MarkUnready(reason, messageFormat string, 
 
 // KubernetesEventSource is the Schema for the kuberneteseventsources API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:categories=all,knative,eventing,sources
 type KubernetesEventSource struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/controller/kuberneteseventsource/reconcile.go
+++ b/pkg/controller/kuberneteseventsource/reconcile.go
@@ -164,11 +164,7 @@ func (r *reconciler) update(ctx context.Context, u *sourcesv1alpha1.KubernetesEv
 
 	if !equality.Semantic.DeepEqual(current.Status, u.Status) {
 		current.Status = u.Status
-		// Until #38113 is merged, we must use Update instead of UpdateStatus to
-		// update the Status block of the Feed resource. UpdateStatus will not
-		// allow changes to the Spec of the resource, which is ideal for ensuring
-		// nothing other than resource status has been updated.
-		return r.Update(ctx, current)
+		return r.Status().Update(ctx, current)
 	}
 
 	return nil

--- a/pkg/controller/sdk/reconciler.go
+++ b/pkg/controller/sdk/reconciler.go
@@ -174,10 +174,9 @@ func (r *Reconciler) update(ctx context.Context, request reconcile.Request, obje
 	}
 	freshFinalizers.SetFinalizers(orgFinalizers.GetFinalizers())
 
-	// Until #38113 is merged, we must use Update instead of UpdateStatus to
-	// update the Status block of the Source resource. UpdateStatus will not
-	// allow changes to the Spec of the resource, which is ideal for ensuring
-	// nothing other than resource status has been updated.
+	// We could use the status subresource here, but since there may be an update
+	// to finalizers also, we have to update the entire object.
+	//TODO(grantr): use status subresource if finalizers did not change
 	if err := r.client.Update(ctx, freshObj); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now that GKE has 1.11 available we can use the status subresource for CRDs. This eliminates the need to manipulate `Spec.Generation`, which is good because eventing-sources doesn't do that yet.

## Proposed Changes

  * Add status subresource to all source CRDs
  * Use status subresource to update KubernetesEventSource status

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
CRDs now enable the status subresource, and controllers use it to update status when possible.
```