### PR TITLE
Make message dumper a releasable thing.

### DIFF
--- a/config/tools/message-dumper.yaml
+++ b/config/tools/message-dumper.yaml
@@ -1,0 +1,12 @@
+# This is a very simple Knative Service that writes the input request to its log.
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: message-dumper
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/eventing-sources/cmd/message_dumper

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -29,6 +29,7 @@ declare -A RELEASES
 RELEASES=(
   ["release.yaml"]="config/default.yaml"
   ["release-with-gcppubsub.yaml"]="config/default-gcppubsub.yaml"
+  ["message-dumper.yaml"]="config/tools/message-dumper.yaml"
 )
 readonly RELEASES
 


### PR DESCRIPTION
## Proposed Changes

  * Add message dumper to the nightly release.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Message Dumper is a standalone release-able tool to help with debugging.
```