### PR TITLE
Adding heartbeats source and receiver as a release-able component.

### DIFF
--- a/config/tools/heartbeats-receiver.yaml
+++ b/config/tools/heartbeats-receiver.yaml
@@ -1,0 +1,13 @@
+# Heartbeats receiver outputs the contents of a heartbeats cloud event as a
+# single log line.
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: heartbeats-receiver
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/eventing-sources/cmd/heartbeats_receiver

--- a/config/tools/heartbeats-source.yaml
+++ b/config/tools/heartbeats-source.yaml
@@ -1,0 +1,16 @@
+# Heartbeats sends a cloud event every <period> seconds to the given sink. It
+# uses a ContainerSource to do this.
+apiVersion: sources.eventing.knative.dev/v1alpha1
+kind: ContainerSource
+metadata:
+  name: heartbeats
+spec:
+  image: github.com/knative/eventing-sources/cmd/heartbeats
+  args:
+  - '--label="<3"'
+  - '--period=2'
+  # TODO: replace the sink with your own service or channel.
+  sink:
+    apiVersion: serving.knative.dev/v1alpha1
+    kind: Service
+    name: heartbeats-receiver

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -30,6 +30,8 @@ RELEASES=(
   ["release.yaml"]="config/default.yaml"
   ["release-with-gcppubsub.yaml"]="config/default-gcppubsub.yaml"
   ["message-dumper.yaml"]="config/tools/message-dumper.yaml"
+  ["heartbeats-source.yaml"]="config/tools/heartbeats-source.yaml"
+  ["heartbeats-receiver.yaml"]="config/tools/heartbeats-receiver.yaml"
 )
 readonly RELEASES
 


### PR DESCRIPTION
## Proposed Changes

  * Release heartbeats as a source example with compiled image.
  * Release heartbeats-receiver as a compiled image.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Releasing heartbeats source and receiver. 
```