### PR TITLE
fix: propagate GH headers into cloud event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bazel-*
 .DS_Store
 cover.out
 bin/
+*.swp

--- a/pkg/githubsource/receive_adapter.go
+++ b/pkg/githubsource/receive_adapter.go
@@ -31,9 +31,8 @@ import (
 )
 
 const (
-	GHHeaderEvent     = "X-GitHub-Event"
-	GHHeaderDelivery  = "X-GitHub-Delivery"
-	CEExtensionPrefix = "CE-"
+	GHHeaderEvent    = "GitHub-Event"
+	GHHeaderDelivery = "GitHub-Delivery"
 )
 
 // GitHubReceiveAdapter converts incoming GitHub webhook events to
@@ -54,11 +53,11 @@ func (ra *GitHubReceiveAdapter) HandleEvent(payload interface{}, header webhooks
 
 func (ra *GitHubReceiveAdapter) handleEvent(payload interface{}, hdr http.Header) error {
 
-	gitHubEventType := hdr.Get(GHHeaderEvent)
-	eventID := hdr.Get(GHHeaderDelivery)
+	gitHubEventType := hdr.Get("X-" + GHHeaderEvent)
+	eventID := hdr.Get("X-" + GHHeaderDelivery)
 	extensions := map[string]interface{}{
-		CEExtensionPrefix + GHHeaderEvent:    hdr.Get(GHHeaderEvent),
-		CEExtensionPrefix + GHHeaderDelivery: hdr.Get(GHHeaderDelivery),
+		cloudevents.HeaderExtensionsPrefix + GHHeaderEvent:    hdr.Get("X-" + GHHeaderEvent),
+		cloudevents.HeaderExtensionsPrefix + GHHeaderDelivery: hdr.Get("X-" + GHHeaderDelivery),
 	}
 
 	log.Printf("Handling %s", gitHubEventType)

--- a/pkg/githubsource/receive_adapter.go
+++ b/pkg/githubsource/receive_adapter.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	GhHeaderEvent     = "X-GitHub-Event"
-	GhHeaderDelivery  = "X-GitHub-Delivery"
-	CeExtensionPrefix = "CE-"
+	GHHeaderEvent     = "X-GitHub-Event"
+	GHHeaderDelivery  = "X-GitHub-Delivery"
+	CEExtensionPrefix = "CE-"
 )
 
 // GitHubReceiveAdapter converts incoming GitHub webhook events to
@@ -54,8 +54,8 @@ func (ra *GitHubReceiveAdapter) HandleEvent(payload interface{}, header webhooks
 
 func (ra *GitHubReceiveAdapter) handleEvent(payload interface{}, hdr http.Header) error {
 
-	gitHubEventType := hdr.Get(GhHeaderEvent)
-	eventID := hdr.Get(GhHeaderDelivery)
+	gitHubEventType := hdr.Get(GHHeaderEvent)
+	eventID := hdr.Get(GHHeaderDelivery)
 
 	log.Printf("Handling %s", gitHubEventType)
 
@@ -79,8 +79,8 @@ func (ra *GitHubReceiveAdapter) postMessage(payload interface{}, source, eventTy
 		EventTime:          time.Now(),
 		Source:             source,
 		Extensions: map[string]interface{}{
-			CeExtensionPrefix + GhHeaderEvent:    hdr.Get(GhHeaderEvent),
-			CeExtensionPrefix + GhHeaderDelivery: hdr.Get(GhHeaderDelivery),
+			CEExtensionPrefix + GHHeaderEvent:    hdr.Get(GHHeaderEvent),
+			CEExtensionPrefix + GHHeaderDelivery: hdr.Get(GHHeaderDelivery),
 		},
 	}
 	req, err := cloudevents.Binary.NewRequest(ra.Sink, payload, ctx)

--- a/pkg/githubsource/receive_adapter_test.go
+++ b/pkg/githubsource/receive_adapter_test.go
@@ -502,14 +502,14 @@ func TestHandleEvent(t *testing.T) {
 				return nil, fmt.Errorf("want eventID %s, got %s", eventID, cloudEvent.EventID)
 			}
 
-			ceHdr := cloudEvent.Extensions[CeExtensionPrefix+GhHeaderDelivery].(string)
+			ceHdr := cloudEvent.Extensions[CEExtensionPrefix+GHHeaderDelivery].(string)
 			if eventID != ceHdr {
-				return nil, fmt.Errorf("%s expected to be %s was %s", GhHeaderDelivery, eventID, ceHdr)
+				return nil, fmt.Errorf("%s expected to be %s was %s", GHHeaderDelivery, eventID, ceHdr)
 			}
 
-			ceHdr = cloudEvent.Extensions[CeExtensionPrefix+GhHeaderEvent].(string)
+			ceHdr = cloudEvent.Extensions[CEExtensionPrefix+GHHeaderEvent].(string)
 			if eventType != ceHdr {
-				return nil, fmt.Errorf("%s expected to be %s was %s", GhHeaderEvent, eventType, ceHdr)
+				return nil, fmt.Errorf("%s expected to be %s was %s", GHHeaderEvent, eventType, ceHdr)
 			}
 
 			success = true
@@ -527,8 +527,8 @@ func TestHandleEvent(t *testing.T) {
 	payload := gh.PullRequestPayload{}
 	payload.PullRequest.HTMLURL = testSource
 	header := http.Header{}
-	header.Set(GhHeaderEvent, eventType)
-	header.Set(GhHeaderDelivery, eventID)
+	header.Set(GHHeaderEvent, eventType)
+	header.Set(GHHeaderDelivery, eventID)
 	ra.HandleEvent(payload, webhooks.Header(header))
 	if !success {
 		t.Error("did not handle event successfully")

--- a/pkg/githubsource/receive_adapter_test.go
+++ b/pkg/githubsource/receive_adapter_test.go
@@ -502,12 +502,12 @@ func TestHandleEvent(t *testing.T) {
 				return nil, fmt.Errorf("want eventID %s, got %s", eventID, cloudEvent.EventID)
 			}
 
-			ceHdr := cloudEvent.Extensions[CEExtensionPrefix+GHHeaderDelivery].(string)
+			ceHdr := cloudEvent.Extensions[cloudevents.HeaderExtensionsPrefix+GHHeaderDelivery].(string)
 			if eventID != ceHdr {
 				return nil, fmt.Errorf("%s expected to be %s was %s", GHHeaderDelivery, eventID, ceHdr)
 			}
 
-			ceHdr = cloudEvent.Extensions[CEExtensionPrefix+GHHeaderEvent].(string)
+			ceHdr = cloudEvent.Extensions[cloudevents.HeaderExtensionsPrefix+GHHeaderEvent].(string)
 			if eventType != ceHdr {
 				return nil, fmt.Errorf("%s expected to be %s was %s", GHHeaderEvent, eventType, ceHdr)
 			}
@@ -527,8 +527,8 @@ func TestHandleEvent(t *testing.T) {
 	payload := gh.PullRequestPayload{}
 	payload.PullRequest.HTMLURL = testSource
 	header := http.Header{}
-	header.Set(GHHeaderEvent, eventType)
-	header.Set(GHHeaderDelivery, eventID)
+	header.Set("X-"+GHHeaderEvent, eventType)
+	header.Set("X-"+GHHeaderDelivery, eventID)
 	ra.HandleEvent(payload, webhooks.Header(header))
 	if !success {
 		t.Error("did not handle event successfully")


### PR DESCRIPTION
Fixes #120 

## Proposed Changes

Encode X-GitHub-Event and X-GitHub-Delivery in Cloud Event extensions, encoded according to:
- https://github.com/cloudevents/spec/blob/v0.1/spec.md#extensions
- https://github.com/cloudevents/spec/blob/v0.1/http-transport-binding.md#3131-http-header-names
