### PR TITLE
Use CR unstructured client for dynamic objects

### DIFF
--- a/pkg/controller/containersource/reconcile.go
+++ b/pkg/controller/containersource/reconcile.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
-	"k8s.io/client-go/rest"
 
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing-sources/pkg/controller/containersource/resources"
@@ -210,9 +209,5 @@ func (r *reconciler) createDeployment(ctx context.Context, source *v1alpha1.Cont
 
 func (r *reconciler) InjectClient(c client.Client) error {
 	r.client = c
-	return nil
-}
-
-func (r *reconciler) InjectConfig(c *rest.Config) error {
 	return nil
 }

--- a/pkg/controller/containersource/reconcile_test.go
+++ b/pkg/controller/containersource/reconcile_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	sourcesv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing-sources/pkg/controller/containersource/resources"
@@ -35,12 +37,11 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 )
 
 var (
 	trueVal   = true
-	targetURI = "http://sinkable.sink.svc.cluster.local/"
+	targetURI = "http://addressable.sink.svc.cluster.local/"
 )
 
 const (
@@ -50,15 +51,15 @@ const (
 	containerSourceUID  = "2a2208d1-ce67-11e8-b3a3-42010a8a00af"
 	deployGeneratedName = "" //sad trombone
 
-	sinkableDNS = "sinkable.sink.svc.cluster.local"
+	addressableDNS = "addressable.sink.svc.cluster.local"
 
-	sinkableName       = "testsink"
-	sinkableKind       = "Sink"
-	sinkableAPIVersion = "duck.knative.dev/v1alpha1"
+	addressableName       = "testsink"
+	addressableKind       = "Sink"
+	addressableAPIVersion = "duck.knative.dev/v1alpha1"
 
-	unsinkableName       = "testunsinkable"
-	unsinkableKind       = "KResource"
-	unsinkableAPIVersion = "duck.knative.dev/v1alpha1"
+	unaddressableName       = "testunaddressable"
+	unaddressableKind       = "KResource"
+	unaddressableAPIVersion = "duck.knative.dev/v1alpha1"
 
 	sinkServiceName       = "testsinkservice"
 	sinkServiceKind       = "Service"
@@ -100,50 +101,21 @@ var testCases = []controllertesting.TestCase{
 		Name:       "valid containersource, but sink is not addressable",
 		Reconciles: &sourcesv1alpha1.ContainerSource{},
 		InitialState: []runtime.Object{
-			getContainerSource_unsinkable(),
+			getContainerSource_unaddressable(),
+			getAddressable_noStatus(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			// unaddressable resource
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": unsinkableAPIVersion,
-					"kind":       unsinkableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      unsinkableName,
-					},
-				},
-			},
-		},
-		WantErrMsg: "sink does not contain address",
+		WantErrMsg:   "sink does not contain address",
 	}, {
 		Name:       "valid containersource, sink is addressable",
 		Reconciles: &sourcesv1alpha1.ContainerSource{},
 		InitialState: []runtime.Object{
 			getContainerSource(),
+			getAddressable(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			// Addressable resource
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": sinkableAPIVersion,
-					"kind":       sinkableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      sinkableName,
-					},
-					"status": map[string]interface{}{
-						"address": map[string]interface{}{
-							"hostname": sinkableDNS,
-						},
-					},
-				},
-			},
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getContainerSource()
@@ -159,27 +131,10 @@ var testCases = []controllertesting.TestCase{
 		Reconciles: &sourcesv1alpha1.ContainerSource{},
 		InitialState: []runtime.Object{
 			getContainerSource_filledIn(),
+			getAddressable(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			// Addressable resource
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": sinkableAPIVersion,
-					"kind":       sinkableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      sinkableName,
-					},
-					"status": map[string]interface{}{
-						"address": map[string]interface{}{
-							"hostname": sinkableDNS,
-						},
-					},
-				},
-			},
-		},
 		WantPresent: []runtime.Object{
 			getDeployment(getContainerSource_filledIn()),
 		},
@@ -189,25 +144,10 @@ var testCases = []controllertesting.TestCase{
 		Reconciles: &sourcesv1alpha1.ContainerSource{},
 		InitialState: []runtime.Object{
 			getContainerSource(),
+			getAddressable_nilAddress(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			// Addressable resource
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": sinkableAPIVersion,
-					"kind":       sinkableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      sinkableName,
-					},
-					"status": map[string]interface{}{
-						"address": map[string]interface{}(nil),
-					},
-				},
-			},
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getContainerSource()
@@ -230,22 +170,6 @@ var testCases = []controllertesting.TestCase{
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			// sinkable resource
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": sinkableAPIVersion,
-					"kind":       sinkableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      sinkableName,
-					},
-					"status": map[string]interface{}{
-						"sinkable": map[string]interface{}(nil),
-					},
-				},
-			},
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getContainerSource()
@@ -270,7 +194,6 @@ var testCases = []controllertesting.TestCase{
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
-		Objects:      []runtime.Object{},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getContainerSource()
@@ -317,34 +240,16 @@ var testCases = []controllertesting.TestCase{
 
 				d1 := resources.MakeDeployment(nil, &resources.ContainerArguments{
 					Name:  containerSourceName,
-					Sink:  "http://" + sinkableDNS + "/",
+					Sink:  "http://" + addressableDNS + "/",
 					Image: image,
 				})
 				d.Spec = d1.Spec
 				return d
 			}(),
+			getAddressable(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			// sinkable
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": sinkableAPIVersion,
-					"kind":       sinkableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      sinkableName,
-						"uid":       containerSourceUID,
-					},
-					"status": map[string]interface{}{
-						"address": map[string]interface{}{
-							"hostname": sinkableDNS,
-						},
-					},
-				},
-			},
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getContainerSource()
@@ -390,34 +295,16 @@ var testCases = []controllertesting.TestCase{
 
 				d1 := resources.MakeDeployment(nil, &resources.ContainerArguments{
 					Name:  containerSourceName,
-					Sink:  "http://old-" + sinkableDNS + "/",
+					Sink:  "http://old-" + addressableDNS + "/",
 					Image: image,
 				})
 				d.Spec = d1.Spec
 				return d
 			}(),
+			getAddressable(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			// sinkable
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": sinkableAPIVersion,
-					"kind":       sinkableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      sinkableName,
-						"uid":       containerSourceUID,
-					},
-					"status": map[string]interface{}{
-						"address": map[string]interface{}{
-							"hostname": sinkableDNS,
-						},
-					},
-				},
-			},
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getContainerSource()
@@ -438,6 +325,7 @@ var testCases = []controllertesting.TestCase{
 				s.UID = containerSourceUID
 				return s
 			}(),
+			getAddressable(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
@@ -445,24 +333,6 @@ var testCases = []controllertesting.TestCase{
 			MockCreates: []controllertesting.MockCreate{
 				func(_ client.Client, _ context.Context, _ runtime.Object) (controllertesting.MockHandled, error) {
 					return controllertesting.Handled, errors.New("force an error into client create")
-				},
-			},
-		},
-		Objects: []runtime.Object{
-			// Addressable resource
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": sinkableAPIVersion,
-					"kind":       sinkableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      sinkableName,
-					},
-					"status": map[string]interface{}{
-						"address": map[string]interface{}{
-							"hostname": sinkableDNS,
-						},
-					},
 				},
 			},
 		},
@@ -477,6 +347,7 @@ var testCases = []controllertesting.TestCase{
 				s.UID = containerSourceUID
 				return s
 			}(),
+			getAddressable(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
@@ -484,24 +355,6 @@ var testCases = []controllertesting.TestCase{
 			MockLists: []controllertesting.MockList{
 				func(_ client.Client, _ context.Context, _ *client.ListOptions, _ runtime.Object) (controllertesting.MockHandled, error) {
 					return controllertesting.Handled, errors.New("force an error into client list")
-				},
-			},
-		},
-		Objects: []runtime.Object{
-			// Addressable resource
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": sinkableAPIVersion,
-					"kind":       sinkableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      sinkableName,
-					},
-					"status": map[string]interface{}{
-						"address": map[string]interface{}{
-							"hostname": sinkableDNS,
-						},
-					},
 				},
 			},
 		},
@@ -517,7 +370,7 @@ var testCases = []controllertesting.TestCase{
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
 		Scheme:       scheme.Scheme,
 		Objects: []runtime.Object{
-			// sinkable
+			// addressable
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": sinkServiceAPIVersion,
@@ -536,12 +389,10 @@ func TestAllCases(t *testing.T) {
 
 	for _, tc := range testCases {
 		c := tc.GetClient()
-		dc := tc.GetDynamicClient()
 
 		r := &reconciler{
-			dynamicClient: dc,
-			scheme:        tc.Scheme,
-			recorder:      recorder,
+			scheme:   tc.Scheme,
+			recorder: recorder,
 		}
 		r.InjectClient(c)
 		t.Run(tc.Name, tc.Runner(t, r, c))
@@ -556,9 +407,9 @@ func getContainerSource() *sourcesv1alpha1.ContainerSource {
 			Image: image,
 			Args:  []string(nil),
 			Sink: &corev1.ObjectReference{
-				Name:       sinkableName,
-				Kind:       sinkableKind,
-				APIVersion: sinkableAPIVersion,
+				Name:       addressableName,
+				Kind:       addressableKind,
+				APIVersion: addressableAPIVersion,
 			},
 		},
 	}
@@ -595,7 +446,7 @@ func getContainerSource_sinkService() *sourcesv1alpha1.ContainerSource {
 	return obj
 }
 
-func getContainerSource_unsinkable() *sourcesv1alpha1.ContainerSource {
+func getContainerSource_unaddressable() *sourcesv1alpha1.ContainerSource {
 	obj := &sourcesv1alpha1.ContainerSource{
 		TypeMeta:   containerSourceType(),
 		ObjectMeta: om(testNS, containerSourceName),
@@ -603,9 +454,9 @@ func getContainerSource_unsinkable() *sourcesv1alpha1.ContainerSource {
 			Image: image,
 			Args:  []string{},
 			Sink: &corev1.ObjectReference{
-				Name:       unsinkableName,
-				Kind:       unsinkableKind,
-				APIVersion: unsinkableAPIVersion,
+				Name:       unaddressableName,
+				Kind:       unaddressableKind,
+				APIVersion: unaddressableAPIVersion,
 			},
 		},
 	}
@@ -614,10 +465,57 @@ func getContainerSource_unsinkable() *sourcesv1alpha1.ContainerSource {
 	return obj
 }
 
+func getAddressable() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": addressableAPIVersion,
+			"kind":       addressableKind,
+			"metadata": map[string]interface{}{
+				"namespace": testNS,
+				"name":      addressableName,
+			},
+			"status": map[string]interface{}{
+				"address": map[string]interface{}{
+					"hostname": addressableDNS,
+				},
+			},
+		},
+	}
+}
+
+func getAddressable_noStatus() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": unaddressableAPIVersion,
+			"kind":       unaddressableKind,
+			"metadata": map[string]interface{}{
+				"namespace": testNS,
+				"name":      unaddressableName,
+			},
+		},
+	}
+}
+
+func getAddressable_nilAddress() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": addressableAPIVersion,
+			"kind":       addressableKind,
+			"metadata": map[string]interface{}{
+				"namespace": testNS,
+				"name":      addressableName,
+			},
+			"status": map[string]interface{}{
+				"address": map[string]interface{}(nil),
+			},
+		},
+	}
+}
+
 func getDeployment(source *sourcesv1alpha1.ContainerSource) *appsv1.Deployment {
-	sinkableURI := fmt.Sprintf("http://%s/", sinkableDNS)
-	args := append(source.Spec.Args, fmt.Sprintf("--sink=%s", sinkableURI))
-	env := append(source.Spec.Env, corev1.EnvVar{Name: "SINK", Value: sinkableURI})
+	addressableURI := fmt.Sprintf("http://%s/", addressableDNS)
+	args := append(source.Spec.Args, fmt.Sprintf("--sink=%s", addressableURI))
+	env := append(source.Spec.Env, corev1.EnvVar{Name: "SINK", Value: addressableURI})
 	return &appsv1.Deployment{
 		TypeMeta: deploymentType(),
 		ObjectMeta: metav1.ObjectMeta{
@@ -693,9 +591,9 @@ func getOwnerReferences() []metav1.OwnerReference {
 func TestObjectNotContainerSource(t *testing.T) {
 	r := reconciler{}
 	obj := &corev1.ObjectReference{
-		Name:       unsinkableName,
-		Kind:       unsinkableKind,
-		APIVersion: unsinkableAPIVersion,
+		Name:       unaddressableName,
+		Kind:       unaddressableKind,
+		APIVersion: unaddressableAPIVersion,
 	}
 
 	got, gotErr := r.Reconcile(context.TODO(), obj)
@@ -730,8 +628,4 @@ func TestInjectConfig(t *testing.T) {
 	r := reconciler{}
 
 	r.InjectConfig(&rest.Config{})
-
-	if r.dynamicClient == nil {
-		t.Errorf("dynamicClient was nil but expected non nil")
-	}
 }

--- a/pkg/controller/containersource/reconcile_test.go
+++ b/pkg/controller/containersource/reconcile_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -622,10 +621,4 @@ func TestObjectHasDeleteTimestamp(t *testing.T) {
 	if diff := cmp.Diff(wantErr, gotErr); diff != "" {
 		t.Errorf("unexpected returned error (-want, +got) = %v", diff)
 	}
-}
-
-func TestInjectConfig(t *testing.T) {
-	r := reconciler{}
-
-	r.InjectConfig(&rest.Config{})
 }

--- a/pkg/controller/gcppubsub/reconcile.go
+++ b/pkg/controller/gcppubsub/reconcile.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -70,10 +69,6 @@ type reconciler struct {
 
 func (r *reconciler) InjectClient(c client.Client) error {
 	r.client = c
-	return nil
-}
-
-func (r *reconciler) InjectConfig(c *rest.Config) error {
 	return nil
 }
 

--- a/pkg/controller/gcppubsub/reconcile.go
+++ b/pkg/controller/gcppubsub/reconcile.go
@@ -19,6 +19,7 @@ package gcppubsub
 import (
 	"context"
 	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/knative/eventing-sources/pkg/controller/gcppubsub/resources"
@@ -36,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -60,9 +60,8 @@ func gcpPubSubClientCreator(ctx context.Context, googleCloudProject string) (pub
 }
 
 type reconciler struct {
-	client        client.Client
-	dynamicClient dynamic.Interface
-	scheme        *runtime.Scheme
+	client client.Client
+	scheme *runtime.Scheme
 
 	pubSubClientCreator pubSubClientCreator
 
@@ -75,9 +74,7 @@ func (r *reconciler) InjectClient(c client.Client) error {
 }
 
 func (r *reconciler) InjectConfig(c *rest.Config) error {
-	var err error
-	r.dynamicClient, err = dynamic.NewForConfig(c)
-	return err
+	return nil
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runtime.Object, error) {
@@ -115,7 +112,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 
 	src.Status.InitializeConditions()
 
-	sinkURI, err := sinks.GetSinkURI(r.dynamicClient, src.Spec.Sink, src.Namespace)
+	sinkURI, err := sinks.GetSinkURI(ctx, r.client, src.Spec.Sink, src.Namespace)
 	if err != nil {
 		src.Status.MarkNoSink("NotFound", "")
 		return src, err

--- a/pkg/controller/gcppubsub/reconcile_test.go
+++ b/pkg/controller/gcppubsub/reconcile_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -86,12 +85,6 @@ type pubSubClientCreatorData struct {
 	subExistsErr    error
 	createSubErr    error
 	deleteSubErr    error
-}
-
-func TestInjectConfig(t *testing.T) {
-	r := reconciler{}
-
-	r.InjectConfig(&rest.Config{})
 }
 
 func TestReconcile(t *testing.T) {

--- a/pkg/controller/gcppubsub/reconcile_test.go
+++ b/pkg/controller/gcppubsub/reconcile_test.go
@@ -54,11 +54,11 @@ const (
 	sourceUID  = "1234-5678-90"
 	testNS     = "testnamespace"
 
-	sinkableName       = "testsink"
-	sinkableKind       = "Sink"
-	sinkableAPIVersion = "duck.knative.dev/v1alpha1"
-	sinkableDNS        = "sinkable.sink.svc.cluster.local"
-	sinkableURI        = "http://sinkable.sink.svc.cluster.local/"
+	addressableName       = "testsink"
+	addressableKind       = "Sink"
+	addressableAPIVersion = "duck.knative.dev/v1alpha1"
+	addressableDNS        = "addressable.sink.svc.cluster.local"
+	addressableURI        = "http://addressable.sink.svc.cluster.local/"
 )
 
 // Adds the list of known types to Scheme.
@@ -92,10 +92,6 @@ func TestInjectConfig(t *testing.T) {
 	r := reconciler{}
 
 	r.InjectConfig(&rest.Config{})
-
-	if r.dynamicClient == nil {
-		t.Errorf("dynamicClient was nil but expected non nil")
-	}
 }
 
 func TestReconcile(t *testing.T) {
@@ -162,8 +158,8 @@ func TestReconcile(t *testing.T) {
 			Name: "cannot create client",
 			InitialState: []runtime.Object{
 				getSource(),
+				getAddressable(),
 			},
-			Objects: getAddressable(),
 			OtherTestData: map[string]interface{}{
 				pscData: pubSubClientCreatorData{
 					clientCreateErr: errors.New("test-induced-error"),
@@ -177,8 +173,8 @@ func TestReconcile(t *testing.T) {
 			Name: "error checking subscription exists",
 			InitialState: []runtime.Object{
 				getSource(),
+				getAddressable(),
 			},
-			Objects: getAddressable(),
 			OtherTestData: map[string]interface{}{
 				pscData: pubSubClientCreatorData{
 					subExistsErr: errors.New("test-induced-error"),
@@ -192,8 +188,8 @@ func TestReconcile(t *testing.T) {
 			Name: "cannot create subscription",
 			InitialState: []runtime.Object{
 				getSource(),
+				getAddressable(),
 			},
-			Objects: getAddressable(),
 			OtherTestData: map[string]interface{}{
 				pscData: pubSubClientCreatorData{
 					createSubErr: errors.New("test-induced-error"),
@@ -207,8 +203,8 @@ func TestReconcile(t *testing.T) {
 			Name: "reusing existing subscription - cannot create receive adapter",
 			InitialState: []runtime.Object{
 				getSource(),
+				getAddressable(),
 			},
-			Objects: getAddressable(),
 			Mocks: controllertesting.Mocks{
 				MockCreates: []controllertesting.MockCreate{
 					func(_ client.Client, _ context.Context, _ runtime.Object) (controllertesting.MockHandled, error) {
@@ -230,8 +226,8 @@ func TestReconcile(t *testing.T) {
 			Name: "cannot create receive adapter",
 			InitialState: []runtime.Object{
 				getSource(),
+				getAddressable(),
 			},
-			Objects: getAddressable(),
 			Mocks: controllertesting.Mocks{
 				MockCreates: []controllertesting.MockCreate{
 					func(_ client.Client, _ context.Context, _ runtime.Object) (controllertesting.MockHandled, error) {
@@ -247,8 +243,8 @@ func TestReconcile(t *testing.T) {
 			Name: "cannot list deployments",
 			InitialState: []runtime.Object{
 				getSource(),
+				getAddressable(),
 			},
-			Objects: getAddressable(),
 			Mocks: controllertesting.Mocks{
 				MockLists: []controllertesting.MockList{
 					func(_ client.Client, _ context.Context, _ *client.ListOptions, _ runtime.Object) (controllertesting.MockHandled, error) {
@@ -264,8 +260,8 @@ func TestReconcile(t *testing.T) {
 			Name: "successful create",
 			InitialState: []runtime.Object{
 				getSource(),
+				getAddressable(),
 			},
-			Objects: getAddressable(),
 			WantPresent: []runtime.Object{
 				getReadySource(),
 			},
@@ -273,9 +269,9 @@ func TestReconcile(t *testing.T) {
 			Name: "successful create - reuse existing receive adapter",
 			InitialState: []runtime.Object{
 				getSource(),
+				getAddressable(),
 				getReceiveAdapter(),
 			},
-			Objects: getAddressable(),
 			Mocks: controllertesting.Mocks{
 				MockCreates: []controllertesting.MockCreate{
 					func(_ client.Client, _ context.Context, _ runtime.Object) (controllertesting.MockHandled, error) {
@@ -298,9 +294,8 @@ func TestReconcile(t *testing.T) {
 
 		c := tc.GetClient()
 		r := &reconciler{
-			client:        c,
-			dynamicClient: tc.GetDynamicClient(),
-			scheme:        tc.Scheme,
+			client: c,
+			scheme: tc.Scheme,
 
 			pubSubClientCreator: createPubSubClientCreator(tc.OtherTestData[pscData]),
 
@@ -322,9 +317,9 @@ func getNonGcpPubSubSource() *sourcesv1alpha1.ContainerSource {
 			Image: image,
 			Args:  []string(nil),
 			Sink: &corev1.ObjectReference{
-				Name:       sinkableName,
-				Kind:       sinkableKind,
-				APIVersion: sinkableAPIVersion,
+				Name:       addressableName,
+				Kind:       addressableKind,
+				APIVersion: addressableAPIVersion,
 			},
 		},
 	}
@@ -350,9 +345,9 @@ func getSource() *sourcesv1alpha1.GcpPubSubSource {
 			GoogleCloudProject: "my-gcp-project",
 			Topic:              "laconia",
 			Sink: &corev1.ObjectReference{
-				Name:       sinkableName,
-				Kind:       sinkableKind,
-				APIVersion: sinkableAPIVersion,
+				Name:       addressableName,
+				Kind:       addressableKind,
+				APIVersion: addressableAPIVersion,
 			},
 		},
 	}
@@ -388,7 +383,7 @@ func getSourceWithFinalizerAndNoSink() *sourcesv1alpha1.GcpPubSubSource {
 
 func getSourceWithFinalizerAndSink() *sourcesv1alpha1.GcpPubSubSource {
 	src := getSourceWithFinalizer()
-	src.Status.MarkSink(sinkableURI)
+	src.Status.MarkSink(addressableURI)
 	return src
 }
 
@@ -431,21 +426,18 @@ func createPubSubClientCreator(value interface{}) pubSubClientCreator {
 	}
 }
 
-func getAddressable() []runtime.Object {
-	return []runtime.Object{
-		// addressable resource
-		&unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": sinkableAPIVersion,
-				"kind":       sinkableKind,
-				"metadata": map[string]interface{}{
-					"namespace": testNS,
-					"name":      sinkableName,
-				},
-				"status": map[string]interface{}{
-					"address": map[string]interface{}{
-						"hostname": sinkableDNS,
-					},
+func getAddressable() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": addressableAPIVersion,
+			"kind":       addressableKind,
+			"metadata": map[string]interface{}{
+				"namespace": testNS,
+				"name":      addressableName,
+			},
+			"status": map[string]interface{}{
+				"address": map[string]interface{}{
+					"hostname": addressableDNS,
 				},
 			},
 		},

--- a/pkg/controller/githubsource/reconcile.go
+++ b/pkg/controller/githubsource/reconcile.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -265,9 +264,5 @@ func (r *reconciler) removeFinalizer(s *sourcesv1alpha1.GitHubSource) {
 
 func (r *reconciler) InjectClient(c client.Client) error {
 	r.client = c
-	return nil
-}
-
-func (r *reconciler) InjectConfig(c *rest.Config) error {
 	return nil
 }

--- a/pkg/controller/githubsource/reconcile.go
+++ b/pkg/controller/githubsource/reconcile.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,7 +48,6 @@ const (
 type reconciler struct {
 	client              client.Client
 	scheme              *runtime.Scheme
-	dynamicClient       dynamic.Interface
 	recorder            record.EventRecorder
 	receiveAdapterImage string
 	webhookClient       webhookClient
@@ -95,7 +93,7 @@ func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitH
 	}
 	source.Status.MarkSecrets()
 
-	uri, err := sinks.GetSinkURI(r.dynamicClient, source.Spec.Sink, source.Namespace)
+	uri, err := sinks.GetSinkURI(ctx, r.client, source.Spec.Sink, source.Namespace)
 	if err != nil {
 		source.Status.MarkNoSink("NotFound", "%s", err)
 		return err
@@ -271,7 +269,5 @@ func (r *reconciler) InjectClient(c client.Client) error {
 }
 
 func (r *reconciler) InjectConfig(c *rest.Config) error {
-	var err error
-	r.dynamicClient, err = dynamic.NewForConfig(c)
-	return err
+	return nil
 }

--- a/pkg/controller/githubsource/reconcile_test.go
+++ b/pkg/controller/githubsource/reconcile_test.go
@@ -106,35 +106,21 @@ var testCases = []controllertesting.TestCase{
 		InitialState: []runtime.Object{
 			getGitHubSourceUnaddressable(),
 			getGitHubSecrets(),
+			getAddressable_noStatus(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			// unaddressable resource
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": unaddressableAPIVersion,
-					"kind":       unaddressableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      unaddressableName,
-					},
-				},
-			},
-		},
-		WantErrMsg: "sink does not contain address",
+		WantErrMsg:   "sink does not contain address",
 	}, {
 		Name:       "valid githubsource, sink is addressable",
 		Reconciles: &sourcesv1alpha1.GitHubSource{},
 		InitialState: []runtime.Object{
 			getGitHubSource(),
 			getGitHubSecrets(),
+			getAddressable(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			getAddressableResource(),
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getGitHubSource()
@@ -151,25 +137,10 @@ var testCases = []controllertesting.TestCase{
 		InitialState: []runtime.Object{
 			getGitHubSource(),
 			getGitHubSecrets(),
+			getAddressable_nilAddress(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			// addressable resource
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": addressableAPIVersion,
-					"kind":       addressableKind,
-					"metadata": map[string]interface{}{
-						"namespace": testNS,
-						"name":      addressableName,
-					},
-					"status": map[string]interface{}{
-						"address": map[string]interface{}(nil),
-					},
-				},
-			},
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getGitHubSource()
@@ -191,12 +162,10 @@ var testCases = []controllertesting.TestCase{
 				return s
 			}(),
 			getGitHubSecrets(),
+			getAddressable(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			getAddressableResource(),
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getGitHubSource()
@@ -237,6 +206,7 @@ var testCases = []controllertesting.TestCase{
 				return svc
 			}(),
 			getGitHubSecrets(),
+			getAddressable(),
 		},
 		OtherTestData: map[string]interface{}{
 			webhookData: webhookCreatorData{
@@ -247,9 +217,6 @@ var testCases = []controllertesting.TestCase{
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			getAddressableResource(),
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getGitHubSource()
@@ -291,6 +258,7 @@ var testCases = []controllertesting.TestCase{
 				return svc
 			}(),
 			getGitHubSecrets(),
+			getAddressable(),
 		},
 		OtherTestData: map[string]interface{}{
 			webhookData: webhookCreatorData{
@@ -300,9 +268,6 @@ var testCases = []controllertesting.TestCase{
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			getAddressableResource(),
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getGitHubSource()
@@ -321,12 +286,10 @@ var testCases = []controllertesting.TestCase{
 		Reconciles: &sourcesv1alpha1.GitHubSource{},
 		InitialState: []runtime.Object{
 			getGitHubSource(),
+			getAddressable(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			getAddressableResource(),
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getGitHubSource()
@@ -343,6 +306,7 @@ var testCases = []controllertesting.TestCase{
 		Reconciles: &sourcesv1alpha1.GitHubSource{},
 		InitialState: []runtime.Object{
 			getGitHubSource(),
+			getAddressable(),
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testNS,
@@ -355,9 +319,6 @@ var testCases = []controllertesting.TestCase{
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			getAddressableResource(),
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getGitHubSource()
@@ -399,6 +360,7 @@ var testCases = []controllertesting.TestCase{
 				return svc
 			}(),
 			getGitHubSecrets(),
+			getAddressable(),
 		},
 		OtherTestData: map[string]interface{}{
 			webhookData: webhookCreatorData{
@@ -409,9 +371,6 @@ var testCases = []controllertesting.TestCase{
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
 		Scheme:       scheme.Scheme,
-		Objects: []runtime.Object{
-			getAddressableResource(),
-		},
 		WantPresent: []runtime.Object{
 			func() runtime.Object {
 				s := getGitHubSource()
@@ -434,7 +393,6 @@ func TestAllCases(t *testing.T) {
 
 	for _, tc := range testCases {
 		c := tc.GetClient()
-		dc := tc.GetDynamicClient()
 
 		var hookData webhookCreatorData
 		var ok bool
@@ -443,9 +401,8 @@ func TestAllCases(t *testing.T) {
 		}
 
 		r := &reconciler{
-			dynamicClient: dc,
-			scheme:        tc.Scheme,
-			recorder:      recorder,
+			scheme:   tc.Scheme,
+			recorder: recorder,
 			webhookClient: &mockWebhookClient{
 				data: hookData,
 			},
@@ -551,7 +508,7 @@ func getOwnerReferences() []metav1.OwnerReference {
 	}}
 }
 
-func getAddressableResource() *unstructured.Unstructured {
+func getAddressable() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": addressableAPIVersion,
@@ -564,6 +521,35 @@ func getAddressableResource() *unstructured.Unstructured {
 				"address": map[string]interface{}{
 					"hostname": addressableDNS,
 				},
+			},
+		},
+	}
+}
+
+func getAddressable_noStatus() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": unaddressableAPIVersion,
+			"kind":       unaddressableKind,
+			"metadata": map[string]interface{}{
+				"namespace": testNS,
+				"name":      unaddressableName,
+			},
+		},
+	}
+}
+
+func getAddressable_nilAddress() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": addressableAPIVersion,
+			"kind":       addressableKind,
+			"metadata": map[string]interface{}{
+				"namespace": testNS,
+				"name":      addressableName,
+			},
+			"status": map[string]interface{}{
+				"address": map[string]interface{}(nil),
 			},
 		},
 	}
@@ -651,10 +637,6 @@ func TestInjectConfig(t *testing.T) {
 	r := reconciler{}
 
 	r.InjectConfig(&rest.Config{})
-
-	if r.dynamicClient == nil {
-		t.Error("dynamicClient was nil but expected non nil")
-	}
 }
 
 func TestOwnerAndRepositoryValid(t *testing.T) {

--- a/pkg/controller/githubsource/reconcile_test.go
+++ b/pkg/controller/githubsource/reconcile_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -631,12 +630,6 @@ func TestObjectNotGitHubSource(t *testing.T) {
 	if diff := cmp.Diff(wantErr, gotErr); diff != "" {
 		t.Errorf("unexpected returned error (-want, +got) = %v", diff)
 	}
-}
-
-func TestInjectConfig(t *testing.T) {
-	r := reconciler{}
-
-	r.InjectConfig(&rest.Config{})
 }
 
 func TestOwnerAndRepositoryValid(t *testing.T) {

--- a/pkg/controller/kuberneteseventsource/provider.go
+++ b/pkg/controller/kuberneteseventsource/provider.go
@@ -22,8 +22,6 @@ import (
 
 	sourcesv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -40,7 +38,6 @@ const (
 // reconciler reconciles a KubernetesEventSource object
 type reconciler struct {
 	client.Client
-	dynamicClient       dynamic.Interface
 	recorder            record.EventRecorder
 	scheme              *runtime.Scheme
 	receiveAdapterImage string
@@ -93,10 +90,4 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	return nil
-}
-
-func (r *reconciler) InjectConfig(c *rest.Config) error {
-	var err error
-	r.dynamicClient, err = dynamic.NewForConfig(c)
-	return err
 }

--- a/pkg/controller/sdk/provider.go
+++ b/pkg/controller/sdk/provider.go
@@ -18,6 +18,7 @@ package sdk
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +31,7 @@ import (
 type KnativeReconciler interface {
 	Reconcile(ctx context.Context, object runtime.Object) (runtime.Object, error)
 	InjectClient(c client.Client) error
+	//TODO(grantr) make these separate interfaces
 	InjectConfig(c *rest.Config) error
 }
 

--- a/pkg/controller/sdk/provider.go
+++ b/pkg/controller/sdk/provider.go
@@ -20,8 +20,6 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -30,9 +28,6 @@ import (
 
 type KnativeReconciler interface {
 	Reconcile(ctx context.Context, object runtime.Object) (runtime.Object, error)
-	InjectClient(c client.Client) error
-	//TODO(grantr) make these separate interfaces
-	InjectConfig(c *rest.Config) error
 }
 
 type Provider struct {

--- a/pkg/controller/sdk/provider.go
+++ b/pkg/controller/sdk/provider.go
@@ -23,11 +23,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 type KnativeReconciler interface {
 	Reconcile(ctx context.Context, object runtime.Object) (runtime.Object, error)
+	inject.Client
 }
 
 type Provider struct {

--- a/pkg/controller/sdk/reconciler.go
+++ b/pkg/controller/sdk/reconciler.go
@@ -25,18 +25,17 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
 type Reconciler struct {
-	client        client.Client
-	dynamicClient dynamic.Interface
-	recorder      record.EventRecorder
-	scheme        *runtime.Scheme
+	client   client.Client
+	recorder record.EventRecorder
+	scheme   *runtime.Scheme
 
 	provider Provider
 }
@@ -91,18 +90,12 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 func (r *Reconciler) InjectClient(c client.Client) error {
 	r.client = c
-	if r.provider.Reconciler != nil {
-		r.provider.Reconciler.InjectClient(c)
-	}
-	return nil
+	_, err := inject.ClientInto(c, r.provider.Reconciler)
+	return err
 }
 
 func (r *Reconciler) InjectConfig(c *rest.Config) error {
-	var err error
-	r.dynamicClient, err = dynamic.NewForConfig(c)
-	if r.provider.Reconciler != nil {
-		r.provider.Reconciler.InjectConfig(c)
-	}
+	_, err := inject.ConfigInto(c, r.provider.Reconciler)
 	return err
 }
 

--- a/pkg/controller/sinks/sinks.go
+++ b/pkg/controller/sinks/sinks.go
@@ -17,29 +17,32 @@ limitations under the License.
 package sinks
 
 import (
+	"context"
 	"fmt"
 
-	duckapis "github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetSinkURI retrieves the sink URI from the object referenced by the given
 // ObjectReference.
-func GetSinkURI(dc dynamic.Interface, sink *corev1.ObjectReference, namespace string) (string, error) {
+func GetSinkURI(ctx context.Context, c client.Client, sink *corev1.ObjectReference, namespace string) (string, error) {
 	if sink == nil {
 		return "", fmt.Errorf("sink ref is nil")
 	}
 
-	obj, err := fetchObjectReference(dc, sink, namespace)
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(sink.GroupVersionKind())
+	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: sink.Name}, u)
 	if err != nil {
 		return "", err
 	}
+
 	t := duckv1alpha1.AddressableType{}
-	err = duck.FromUnstructured(obj, &t)
+	err = duck.FromUnstructured(u, &t)
 	if err != nil {
 		return "", fmt.Errorf("failed to deserialize sink: %v", err)
 	}
@@ -53,21 +56,4 @@ func GetSinkURI(dc dynamic.Interface, sink *corev1.ObjectReference, namespace st
 	}
 
 	return fmt.Sprintf("http://%s/", t.Status.Address.Hostname), nil
-}
-
-func fetchObjectReference(dc dynamic.Interface, ref *corev1.ObjectReference, namespace string) (duck.Marshalable, error) {
-	resourceClient, err := createResourceInterface(dc, ref, namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	return resourceClient.Get(ref.Name, metav1.GetOptions{})
-}
-
-func createResourceInterface(dc dynamic.Interface, ref *corev1.ObjectReference, namespace string) (dynamic.ResourceInterface, error) {
-	rc := dc.Resource(duckapis.KindToResource(ref.GroupVersionKind()))
-	if rc == nil {
-		return nil, fmt.Errorf("failed to create dynamic client resource")
-	}
-	return rc.Namespace(namespace), nil
 }


### PR DESCRIPTION
Since https://github.com/kubernetes-sigs/controller-runtime/pull/101, controller-runtime will create and manage dynamic clients when given `unstructured.Unstructured` objects with a filled in `TypeMeta`. Using this allows us to eliminate the dynamic clients created to deal with Addressable objects.

Also updates tests to call the interface Addressable instead of Sinkable.