### PR TITLE
Allow deleting a GitHubSource with a missing sink

### DIFF
--- a/pkg/controller/githubsource/reconcile.go
+++ b/pkg/controller/githubsource/reconcile.go
@@ -95,9 +95,12 @@ func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitH
 	uri, err := sinks.GetSinkURI(ctx, r.client, source.Spec.Sink, source.Namespace)
 	if err != nil {
 		source.Status.MarkNoSink("NotFound", "%s", err)
-		return err
+		if !deleted {
+			return err
+		}
+	} else {
+		source.Status.MarkSink(uri)
 	}
-	source.Status.MarkSink(uri)
 
 	ksvc, err := r.getOwnedService(ctx, source)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/672.

There's probably a larger refactoring needed to make the logic cleaner, but this smaller fix should get in more quickly.

## Proposed Changes

  * Don't return early if sink is missing and source is deleted

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
GitHubSource objects can now be deleted even if their sink is missing.
```