### PR TITLE
Split GitHubSource finalizer into separate method

### DIFF
--- a/pkg/controller/githubsource/reconcile.go
+++ b/pkg/controller/githubsource/reconcile.go
@@ -70,14 +70,18 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 		logger.Warnf("Failed to get metadata accessor: %s", zap.Error(err))
 		return object, err
 	}
-	deleted := accessor.GetDeletionTimestamp() != nil
 
-	reconcileErr := r.reconcile(ctx, source, deleted)
+	var reconcileErr error
+	if accessor.GetDeletionTimestamp() == nil {
+		reconcileErr = r.reconcile(ctx, source)
+	} else {
+		reconcileErr = r.finalize(ctx, source)
+	}
+
 	return source, reconcileErr
 }
 
-func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitHubSource, deleted bool) error {
-	r.addFinalizer(source)
+func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitHubSource) error {
 	source.Status.InitializeConditions()
 
 	accessToken, err := r.secretFrom(ctx, source.Namespace, source.Spec.AccessToken.SecretKeyRef)
@@ -101,12 +105,12 @@ func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitH
 
 	ksvc, err := r.getOwnedService(ctx, source)
 	if err != nil {
-		if apierrors.IsNotFound(err) && !deleted {
-			ksvc := resources.MakeService(source, r.receiveAdapterImage)
-			if err := controllerutil.SetControllerReference(source, ksvc, r.scheme); err != nil {
+		if apierrors.IsNotFound(err) {
+			ksvc = resources.MakeService(source, r.receiveAdapterImage)
+			if err = controllerutil.SetControllerReference(source, ksvc, r.scheme); err != nil {
 				return err
 			}
-			if err := r.client.Create(ctx, ksvc); err != nil {
+			if err = r.client.Create(ctx, ksvc); err != nil {
 				return err
 			}
 			r.recorder.Eventf(source, corev1.EventTypeNormal, "ServiceCreated", "Created Service %q", ksvc.Name)
@@ -114,33 +118,52 @@ func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitH
 			// Wait for the Service to get a status
 			return nil
 		}
-	} else {
-		if deleted {
-			if source.Status.WebhookIDKey != "" {
-				err := r.deleteWebhook(ctx, source, accessToken, source.Status.WebhookIDKey)
-				if err != nil {
-					return err
-				}
-				source.Status.WebhookIDKey = ""
-				r.removeFinalizer(source)
+		// Error was something other than NotFound
+		return err
+	}
+
+	routeCondition := ksvc.Status.GetCondition(servingv1alpha1.ServiceConditionRoutesReady)
+	receiveAdapterDomain := ksvc.Status.Domain
+	if routeCondition != nil && routeCondition.Status == corev1.ConditionTrue && receiveAdapterDomain != "" {
+		// TODO: Mark Deployed for the ksvc
+		// TODO: Mark some condition for the webhook status?
+		r.addFinalizer(source)
+		if source.Status.WebhookIDKey == "" {
+			hookID, err := r.createWebhook(ctx, source,
+				receiveAdapterDomain, accessToken, secretToken)
+			if err != nil {
+				return err
 			}
-			return nil
+			source.Status.WebhookIDKey = hookID
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) finalize(ctx context.Context, source *sourcesv1alpha1.GitHubSource) error {
+	// Always remove the finalizer. If there's a failure cleaning up, an event
+	// will be recorded allowing the webhook to be removed manually by the
+	// operator.
+	r.removeFinalizer(source)
+
+	// If a webhook was created, try to delete it
+	if source.Status.WebhookIDKey != "" {
+		// Get access token
+		accessToken, err := r.secretFrom(ctx, source.Namespace, source.Spec.AccessToken.SecretKeyRef)
+		if err != nil {
+			source.Status.MarkNoSecrets("AccessTokenNotFound", "%s", err)
+			r.recorder.Eventf(source, corev1.EventTypeWarning, "FailedFinalize", "Could not delete webhook %q: %v", source.Status.WebhookIDKey, err)
+			return err
 		}
 
-		routeCondition := ksvc.Status.GetCondition(servingv1alpha1.ServiceConditionRoutesReady)
-		receiveAdapterDomain := ksvc.Status.Domain
-		if routeCondition != nil && routeCondition.Status == corev1.ConditionTrue && receiveAdapterDomain != "" {
-			// TODO: Mark Deployed for the ksvc
-			// TODO: Mark some condition for the webhook status?
-			if source.Status.WebhookIDKey == "" {
-				hookID, err := r.createWebhook(ctx, source,
-					receiveAdapterDomain, accessToken, secretToken)
-				if err != nil {
-					return err
-				}
-				source.Status.WebhookIDKey = hookID
-			}
+		// Delete the webhook using the access token and stored webhook ID
+		err = r.deleteWebhook(ctx, source, accessToken, source.Status.WebhookIDKey)
+		if err != nil {
+			r.recorder.Eventf(source, corev1.EventTypeWarning, "FailedFinalize", "Could not delete webhook %q: %v", source.Status.WebhookIDKey, err)
+			return err
 		}
+		// Webhook deleted, clear ID
+		source.Status.WebhookIDKey = ""
 	}
 	return nil
 }

--- a/pkg/controller/githubsource/reconcile_test.go
+++ b/pkg/controller/githubsource/reconcile_test.go
@@ -374,9 +374,6 @@ var testCases = []controllertesting.TestCase{
 			func() runtime.Object {
 				s := getGitHubSource()
 				s.UID = gitHubSourceUID
-				s.Status.InitializeConditions()
-				s.Status.MarkSink(addressableURI)
-				s.Status.MarkSecrets()
 				s.DeletionTimestamp = &now
 				s.Status.WebhookIDKey = ""
 				s.Finalizers = nil
@@ -384,6 +381,77 @@ var testCases = []controllertesting.TestCase{
 			}(),
 		},
 		IgnoreTimes: true,
+	}, {
+		Name:       "valid githubsource, deleted, missing addressable",
+		Reconciles: &sourcesv1alpha1.GitHubSource{},
+		InitialState: []runtime.Object{
+			func() runtime.Object {
+				s := getGitHubSource()
+				s.UID = gitHubSourceUID
+				s.DeletionTimestamp = &now
+				s.Status.WebhookIDKey = "repohookid"
+				return s
+			}(),
+			getGitHubSecrets(),
+		},
+		OtherTestData: map[string]interface{}{
+			webhookData: webhookCreatorData{
+				expectedOwner: "myuser",
+				expectedRepo:  "myproject",
+				hookID:        "repohookid",
+			},
+		},
+		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
+		Scheme:       scheme.Scheme,
+		WantPresent: []runtime.Object{
+			func() runtime.Object {
+				s := getGitHubSource()
+				s.UID = gitHubSourceUID
+				s.DeletionTimestamp = &now
+				s.Status.WebhookIDKey = ""
+				s.Finalizers = nil
+				return s
+			}(),
+		},
+		IgnoreTimes: true,
+	}, {
+		Name:       "valid githubsource, deleted, missing secret",
+		Reconciles: &sourcesv1alpha1.GitHubSource{},
+		InitialState: []runtime.Object{
+			func() runtime.Object {
+				s := getGitHubSource()
+				s.UID = gitHubSourceUID
+				s.DeletionTimestamp = &now
+				s.Status.WebhookIDKey = "repohookid"
+				return s
+			}(),
+		},
+		OtherTestData: map[string]interface{}{
+			webhookData: webhookCreatorData{
+				expectedOwner: "myuser",
+				expectedRepo:  "myproject",
+				hookID:        "repohookid",
+			},
+		},
+		ReconcileKey: fmt.Sprintf("%s/%s", testNS, gitHubSourceName),
+		Scheme:       scheme.Scheme,
+		WantPresent: []runtime.Object{
+			func() runtime.Object {
+				s := getGitHubSource()
+				s.UID = gitHubSourceUID
+				s.Status.MarkNoSecrets("AccessTokenNotFound", "%s", fmt.Errorf("secrets %q not found", secretName))
+				s.DeletionTimestamp = &now
+				s.Status.WebhookIDKey = "repohookid"
+				s.Finalizers = nil
+				return s
+			}(),
+			//TODO check for Event
+			// Type: Warning
+			// Reason: FailedFinalize
+			// Message: Could not delete webhook "repohookid": secrets "testsecret" not found
+		},
+		IgnoreTimes: true,
+		WantErrMsg:  fmt.Sprintf("secrets %q not found", secretName),
 	},
 }
 


### PR DESCRIPTION
The finalization pass only cares about the access token and deleting the webhook. Splitting it into a separate method simplifies both the reconcile and finalize flows.

Now the controller will attempt to delete the webhook only once. If the first attempt fails, the finalizer is removed anyway. In this case an event is recorded with the webhook id so the operator can delete the webhook manually if desired.

Removal of the finalizer no longer depends on the addressable being present.

Fixes https://github.com/knative/eventing/issues/672.
Replaces #144.

**Release Note**
```release-note
GitHubSource objects can now be deleted if their sink or secret are missing.
In case of webhook deletion failure, a Kubernetes event will be generated
containing the webhook's id so it can be deleted manually.
```