### PR TITLE
golang format tools

### DIFF
--- a/cmd/gcppubsub_receive_adapter/main.go
+++ b/cmd/gcppubsub_receive_adapter/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/eventing-sources/pkg/adapter/gcppubsub"
 	"log"
 	"os"
+
+	"github.com/knative/eventing-sources/pkg/adapter/gcppubsub"
 
 	"go.uber.org/zap"
 

--- a/cmd/heartbeats/main.go
+++ b/cmd/heartbeats/main.go
@@ -18,13 +18,14 @@ package main
 
 import (
 	"flag"
-	"github.com/google/uuid"
-	"github.com/knative/pkg/cloudevents"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/knative/pkg/cloudevents"
 )
 
 type Heartbeat struct {

--- a/cmd/heartbeats_receiver/main.go
+++ b/cmd/heartbeats_receiver/main.go
@@ -18,10 +18,11 @@ package main
 
 import (
 	"context"
-	"github.com/knative/pkg/cloudevents"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/knative/pkg/cloudevents"
 )
 
 type Heartbeat struct {

--- a/cmd/kuberneteseventsource/main.go
+++ b/cmd/kuberneteseventsource/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/pkg/signals"
 	"log"
+
+	"github.com/knative/pkg/signals"
 
 	"github.com/knative/eventing-sources/pkg/adapter/kubernetesevents"
 	"go.uber.org/zap"

--- a/pkg/adapter/gcppubsub/adapter.go
+++ b/pkg/adapter/gcppubsub/adapter.go
@@ -18,10 +18,11 @@ package gcppubsub
 
 import (
 	"fmt"
-	"github.com/knative/pkg/logging"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/knative/pkg/logging"
+	"go.uber.org/zap"
 
 	// Imports the Google Cloud Pub/Sub client package.
 	"cloud.google.com/go/pubsub"

--- a/pkg/adapter/gcppubsub/adapter_test.go
+++ b/pkg/adapter/gcppubsub/adapter_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package gcppubsub
 
 import (
-	"cloud.google.com/go/pubsub"
 	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"cloud.google.com/go/pubsub"
 )
 
 func TestPostMessage_ServeHTTP(t *testing.T) {

--- a/pkg/apis/sources/v1alpha1/containersource_types_test.go
+++ b/pkg/apis/sources/v1alpha1/containersource_types_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/google/go-cmp/cmp"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"

--- a/pkg/apis/sources/v1alpha1/gcp_pubsub_types_test.go
+++ b/pkg/apis/sources/v1alpha1/gcp_pubsub_types_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
 )
 
 func TestGcpPubSubSourceStatusIsReady(t *testing.T) {

--- a/pkg/apis/sources/v1alpha1/register_test.go
+++ b/pkg/apis/sources/v1alpha1/register_test.go
@@ -16,9 +16,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"testing"
 )
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource

--- a/pkg/controller/containersource/resources/deployment_test.go
+++ b/pkg/controller/containersource/resources/deployment_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package resources
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestMakeDeployment_sink(t *testing.T) {

--- a/pkg/controller/gcppubsub/resources/receive_adapter_test.go
+++ b/pkg/controller/gcppubsub/resources/receive_adapter_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package resources
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestMakeReceiveAdapter(t *testing.T) {

--- a/pkg/controller/testing/mock_client.go
+++ b/pkg/controller/testing/mock_client.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
