### PR TITLE
golang format tools

### DIFF
--- a/cmd/githubsource/main.go
+++ b/cmd/githubsource/main.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"github.com/knative/eventing-sources/pkg/githubsource"
-	"gopkg.in/go-playground/webhooks.v3"
+	webhooks "gopkg.in/go-playground/webhooks.v3"
 	gh "gopkg.in/go-playground/webhooks.v3/github"
 )
 

--- a/pkg/controller/cronjobsource/provider.go
+++ b/pkg/controller/cronjobsource/provider.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing-sources/pkg/controller/sdk"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )

--- a/pkg/controller/cronjobsource/reconcile.go
+++ b/pkg/controller/cronjobsource/reconcile.go
@@ -25,7 +25,7 @@ import (
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/cronjobsource/reconcile_test.go
+++ b/pkg/controller/cronjobsource/reconcile_test.go
@@ -25,7 +25,7 @@ import (
 	sourcesv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	controllertesting "github.com/knative/eventing-sources/pkg/controller/testing"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/controller/cronjobsource/resources/receive_adapter.go
+++ b/pkg/controller/cronjobsource/resources/receive_adapter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/controller/cronjobsource/resources/receive_adapter_test.go
+++ b/pkg/controller/cronjobsource/resources/receive_adapter_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/controller/gcppubsub/provider.go
+++ b/pkg/controller/gcppubsub/provider.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing-sources/pkg/controller/sdk"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )

--- a/pkg/controller/gcppubsub/reconcile.go
+++ b/pkg/controller/gcppubsub/reconcile.go
@@ -30,7 +30,7 @@ import (
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/controller/gcppubsub/reconcile_test.go
+++ b/pkg/controller/gcppubsub/reconcile_test.go
@@ -26,7 +26,7 @@ import (
 	sourcesv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	controllertesting "github.com/knative/eventing-sources/pkg/controller/testing"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/controller/gcppubsub/resources/receive_adapter.go
+++ b/pkg/controller/gcppubsub/resources/receive_adapter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/controller/gcppubsub/resources/receive_adapter_test.go
+++ b/pkg/controller/gcppubsub/resources/receive_adapter_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/controller/sdk/finalizers_accessor_test.go
+++ b/pkg/controller/sdk/finalizers_accessor_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
