### PR TITLE
golang format tools

### DIFF
--- a/cmd/awssqs_receive_adapter/main.go
+++ b/cmd/awssqs_receive_adapter/main.go
@@ -18,10 +18,11 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/eventing-sources/pkg/adapter/awssqs"
-	"github.com/knative/pkg/signals"
 	"log"
 	"os"
+
+	"github.com/knative/eventing-sources/pkg/adapter/awssqs"
+	"github.com/knative/pkg/signals"
 
 	"go.uber.org/zap"
 

--- a/pkg/adapter/awssqs/adapter.go
+++ b/pkg/adapter/awssqs/adapter.go
@@ -18,6 +18,12 @@ package awssqs
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -25,11 +31,6 @@ import (
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
-	"io/ioutil"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const (

--- a/pkg/adapter/awssqs/adapter_test.go
+++ b/pkg/adapter/awssqs/adapter_test.go
@@ -18,11 +18,12 @@ package awssqs
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go/service/sqs"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
 func TestPostMessage_ServeHTTP(t *testing.T) {

--- a/pkg/apis/sources/v1alpha1/aws_sqs_types_test.go
+++ b/pkg/apis/sources/v1alpha1/aws_sqs_types_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
 )
 
 func TestAwsSqsSourceStatusIsReady(t *testing.T) {

--- a/pkg/controller/awssqs/provider.go
+++ b/pkg/controller/awssqs/provider.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing-sources/pkg/controller/sdk"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )

--- a/pkg/controller/awssqs/reconcile.go
+++ b/pkg/controller/awssqs/reconcile.go
@@ -27,7 +27,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/controller/awssqs/resources/receive_adapter.go
+++ b/pkg/controller/awssqs/resources/receive_adapter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
