### PR TITLE
Align GitHubSource receive adapter naming with others

### DIFF
--- a/cmd/github_receive_adapter/main.go
+++ b/cmd/github_receive_adapter/main.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/knative/eventing-sources/pkg/githubsource"
+	"github.com/knative/eventing-sources/pkg/adapter/github"
 	webhooks "gopkg.in/go-playground/webhooks.v3"
 	gh "gopkg.in/go-playground/webhooks.v3/github"
 )
@@ -56,7 +56,7 @@ func main() {
 
 	log.Printf("Sink is: %q", *sink)
 
-	ra := &githubsource.GitHubReceiveAdapter{
+	ra := &github.Adapter{
 		Sink: *sink,
 	}
 

--- a/config/default-awssqs.yaml
+++ b/config/default-awssqs.yaml
@@ -697,7 +697,7 @@ spec:
         - name: K8S_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/kuberneteseventsource
         - name: GH_RA_IMAGE
-          value: github.com/knative/eventing-sources/cmd/githubsource
+          value: github.com/knative/eventing-sources/cmd/github_receive_adapter
         - name: CRONJOB_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/cronjob_receive_adapter
         image: github.com/knative/eventing-sources/cmd/manager

--- a/config/default-gcppubsub.yaml
+++ b/config/default-gcppubsub.yaml
@@ -697,7 +697,7 @@ spec:
         - name: K8S_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/kuberneteseventsource
         - name: GH_RA_IMAGE
-          value: github.com/knative/eventing-sources/cmd/githubsource
+          value: github.com/knative/eventing-sources/cmd/github_receive_adapter
         - name: CRONJOB_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/cronjob_receive_adapter
         image: github.com/knative/eventing-sources/cmd/manager

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -618,7 +618,7 @@ spec:
         - name: K8S_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/kuberneteseventsource
         - name: GH_RA_IMAGE
-          value: github.com/knative/eventing-sources/cmd/githubsource
+          value: github.com/knative/eventing-sources/cmd/github_receive_adapter
         - name: CRONJOB_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/cronjob_receive_adapter
         image: github.com/knative/eventing-sources/cmd/manager

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -12,6 +12,6 @@ spec:
         - name: K8S_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/kuberneteseventsource
         - name: GH_RA_IMAGE
-          value: github.com/knative/eventing-sources/cmd/githubsource
+          value: github.com/knative/eventing-sources/cmd/github_receive_adapter
         - name: CRONJOB_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/cronjob_receive_adapter

--- a/pkg/adapter/github/adapter.go
+++ b/pkg/adapter/github/adapter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package githubsource
+package github
 
 import (
 	"fmt"
@@ -35,15 +35,15 @@ const (
 	GHHeaderDelivery = "GitHub-Delivery"
 )
 
-// GitHubReceiveAdapter converts incoming GitHub webhook events to
-// CloudEvents and then sends them to the specified Sink
-type GitHubReceiveAdapter struct {
+// Adapter converts incoming GitHub webhook events to CloudEvents and
+// then sends them to the specified Sink
+type Adapter struct {
 	Sink   string
 	Client *http.Client
 }
 
 // HandleEvent is invoked whenever an event comes in from GitHub
-func (ra *GitHubReceiveAdapter) HandleEvent(payload interface{}, header webhooks.Header) {
+func (ra *Adapter) HandleEvent(payload interface{}, header webhooks.Header) {
 	hdr := http.Header(header)
 	err := ra.handleEvent(payload, hdr)
 	if err != nil {
@@ -51,7 +51,7 @@ func (ra *GitHubReceiveAdapter) HandleEvent(payload interface{}, header webhooks
 	}
 }
 
-func (ra *GitHubReceiveAdapter) handleEvent(payload interface{}, hdr http.Header) error {
+func (ra *Adapter) handleEvent(payload interface{}, hdr http.Header) error {
 
 	gitHubEventType := hdr.Get("X-" + GHHeaderEvent)
 	eventID := hdr.Get("X-" + GHHeaderDelivery)
@@ -74,7 +74,7 @@ func (ra *GitHubReceiveAdapter) handleEvent(payload interface{}, hdr http.Header
 	return ra.postMessage(payload, source, cloudEventType, eventID, extensions)
 }
 
-func (ra *GitHubReceiveAdapter) postMessage(payload interface{}, source, eventType, eventID string,
+func (ra *Adapter) postMessage(payload interface{}, source, eventType, eventID string,
 	extensions map[string]interface{}) error {
 	ctx := cloudevents.EventContext{
 		CloudEventsVersion: cloudevents.CloudEventsVersion,

--- a/pkg/adapter/github/adapter_test.go
+++ b/pkg/adapter/github/adapter_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package githubsource
+package github
 
 import (
 	"bytes"
@@ -418,7 +418,7 @@ func TestAllCases(t *testing.T) {
 		client := &http.Client{
 			Transport: mockTransport(tc.handleRequest),
 		}
-		ra := GitHubReceiveAdapter{
+		ra := Adapter{
 			Sink:   "http://addressable.sink.svc.cluster.local",
 			Client: client,
 		}
@@ -427,7 +427,7 @@ func TestAllCases(t *testing.T) {
 }
 
 // runner returns a testing func that can be passed to t.Run.
-func (tc *testCase) runner(t *testing.T, ra GitHubReceiveAdapter) func(t *testing.T) {
+func (tc *testCase) runner(t *testing.T, ra Adapter) func(t *testing.T) {
 	return func(t *testing.T) {
 		if tc.eventType == "" {
 			t.Fatal("eventType is required for table tests")
@@ -520,7 +520,7 @@ func TestHandleEvent(t *testing.T) {
 			}, nil
 		}),
 	}
-	ra := GitHubReceiveAdapter{
+	ra := Adapter{
 		Sink:   "http://addressable.sink.svc.cluster.local",
 		Client: client,
 	}


### PR DESCRIPTION
This renames or moves a few files related to GitHubSource to better align with the emerging convention for receive adapters.

This change should be transparent to people deploying Knative as the next `release.yaml` will reference the new receive adapter image location.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```