### PR TITLE
Improve error messages when event delivery fails.

### DIFF
--- a/cmd/awssqs_receive_adapter/main.go
+++ b/cmd/awssqs_receive_adapter/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/knative/pkg/signals"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"golang.org/x/net/context"
 )
@@ -52,7 +53,9 @@ func main() {
 	flag.Parse()
 
 	ctx := context.Background()
-	logger, err := zap.NewProduction()
+	logCfg := zap.NewProductionConfig()
+	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := logCfg.Build()
 	if err != nil {
 		log.Fatalf("Unable to create logger: %v", err)
 	}

--- a/cmd/cronjob_receive_adapter/main.go
+++ b/cmd/cronjob_receive_adapter/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/knative/eventing-sources/pkg/adapter/cronjobevents"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"golang.org/x/net/context"
 )
@@ -50,7 +51,9 @@ func main() {
 	flag.Parse()
 
 	ctx := context.Background()
-	logger, err := zap.NewProduction()
+	logCfg := zap.NewProductionConfig()
+	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := logCfg.Build()
 	if err != nil {
 		log.Fatalf("Unable to create logger: %v", err)
 	}

--- a/cmd/kuberneteseventsource/main.go
+++ b/cmd/kuberneteseventsource/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/knative/eventing-sources/pkg/adapter/kubernetesevents"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -39,7 +40,10 @@ func init() {
 func main() {
 	flag.Parse()
 
-	logger, err := zap.NewProduction()
+	logConfig := zap.NewProductionConfig()
+	logConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := logConfig.Build()
+		
 	if err != nil {
 		log.Fatalf("unable to create logger: %v", err)
 	}

--- a/contrib/gcppubsub/cmd/receive_adapter/main.go
+++ b/contrib/gcppubsub/cmd/receive_adapter/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/eventing-sources/contrib/gcppubsub/pkg/adapter"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"golang.org/x/net/context"
 )
@@ -56,7 +57,9 @@ func main() {
 	flag.Parse()
 
 	ctx := context.Background()
-	logger, err := zap.NewProduction()
+	logCfg := zap.NewProductionConfig()
+	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := logCfg.Build()
 	if err != nil {
 		log.Fatalf("Unable to create logger: %v", err)
 	}

--- a/pkg/adapter/awssqs/adapter_test.go
+++ b/pkg/adapter/awssqs/adapter_test.go
@@ -23,6 +23,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
@@ -67,7 +69,7 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 				Body:       &body,
 				Attributes: attrs,
 			}
-			err := a.postMessage(context.TODO(), m)
+			err := a.postMessage(context.TODO(), zap.S(), m)
 
 			if tc.error && err == nil {
 				t.Errorf("expected error, but got %v", err)

--- a/pkg/adapter/cronjobevents/adapter_test.go
+++ b/pkg/adapter/cronjobevents/adapter_test.go
@@ -19,6 +19,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func TestPostMessage_ServeHTTP(t *testing.T) {
@@ -54,7 +56,7 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 				ID:   "ABC",
 				Body: a.Data,
 			}
-			err := a.postMessage(context.TODO(), m)
+			err := a.postMessage(context.TODO(), zap.S(), m)
 
 			if tc.error && err == nil {
 				t.Errorf("expected error, but got %v", err)

--- a/pkg/adapter/kubernetesevents/adapter_test.go
+++ b/pkg/adapter/kubernetesevents/adapter_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -146,9 +148,9 @@ func TestPostMessage_InvalidSink(t *testing.T) {
 		InvolvedObject: ref,
 	}
 
-	err := a.postMessage(event)
+	err := a.postMessage(zap.S(), event)
 
-	want := `Post @#$@: unsupported protocol scheme ""`
+	want := `POST failed: Post @#$@: unsupported protocol scheme ""`
 	if err == nil || err.Error() != want {
 		t.Errorf("want %q, got: %q", want, err.Error())
 	}


### PR DESCRIPTION
## Proposed Changes

  * Reworks the delivery logging for several receive adapters which weren't using `zap` very effectively.
  * Improves the timestamp logging output to specify the time in ISO8601 format the same way that serving does (i.e. using the "ts" key)

<!--
/assign ahmetb
-->