### PR TITLE
golang format tools

### DIFF
--- a/cmd/kuberneteseventsource/main.go
+++ b/cmd/kuberneteseventsource/main.go
@@ -43,7 +43,7 @@ func main() {
 	logConfig := zap.NewProductionConfig()
 	logConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logger, err := logConfig.Build()
-		
+
 	if err != nil {
 		log.Fatalf("unable to create logger: %v", err)
 	}

--- a/contrib/gcppubsub/cmd/receive_adapter/main.go
+++ b/contrib/gcppubsub/cmd/receive_adapter/main.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/knative/eventing-sources/contrib/gcppubsub/pkg/adapter"
+	gcppubsub "github.com/knative/eventing-sources/contrib/gcppubsub/pkg/adapter"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
