### PR TITLE
Soft-revert #137 "Use CR unstructured client for dynamic objects"

### DIFF
--- a/pkg/controller/awssqssource/reconcile.go
+++ b/pkg/controller/awssqssource/reconcile.go
@@ -92,7 +92,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 
 	src.Status.InitializeConditions()
 
-	sinkURI, err := sinks.GetSinkURI(ctx, r.client, src.Spec.Sink, src.Namespace)
+	sinkURI, err := sinks.GetSinkURI_CR(ctx, r.client, src.Spec.Sink, src.Namespace)
 	if err != nil {
 		src.Status.MarkNoSink("NotFound", "")
 		return src, err

--- a/pkg/controller/containersource/reconcile.go
+++ b/pkg/controller/containersource/reconcile.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+	"k8s.io/client-go/rest"
 
 	"github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing-sources/pkg/controller/containersource/resources"
@@ -36,15 +37,17 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 type reconciler struct {
-	client   client.Client
-	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	client        client.Client
+	scheme        *runtime.Scheme
+	dynamicClient dynamic.Interface
+	recorder      record.EventRecorder
 }
 
 // Reconcile compares the actual state with the desired, and attempts to
@@ -81,7 +84,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 		ServiceAccountName: source.Spec.ServiceAccountName,
 	}
 
-	err = r.setSinkURIArg(ctx, source, args)
+	err = r.setSinkURIArg(source, args)
 	if err != nil {
 		return source, err
 	}
@@ -131,7 +134,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 	return source, nil
 }
 
-func (r *reconciler) setSinkURIArg(ctx context.Context, source *v1alpha1.ContainerSource, args *resources.ContainerArguments) error {
+func (r *reconciler) setSinkURIArg(source *v1alpha1.ContainerSource, args *resources.ContainerArguments) error {
 	if uri, ok := sinkArg(source); ok {
 		args.SinkInArgs = true
 		source.Status.MarkSink(uri)
@@ -143,7 +146,7 @@ func (r *reconciler) setSinkURIArg(ctx context.Context, source *v1alpha1.Contain
 		return fmt.Errorf("Sink missing from spec")
 	}
 
-	uri, err := sinks.GetSinkURI(ctx, r.client, source.Spec.Sink, source.Namespace)
+	uri, err := sinks.GetSinkURI(r.dynamicClient, source.Spec.Sink, source.Namespace)
 	if err != nil {
 		source.Status.MarkNoSink("NotFound", "")
 		return err
@@ -210,4 +213,10 @@ func (r *reconciler) createDeployment(ctx context.Context, source *v1alpha1.Cont
 func (r *reconciler) InjectClient(c client.Client) error {
 	r.client = c
 	return nil
+}
+
+func (r *reconciler) InjectConfig(c *rest.Config) error {
+	var err error
+	r.dynamicClient, err = dynamic.NewForConfig(c)
+	return err
 }

--- a/pkg/controller/cronjobsource/reconcile.go
+++ b/pkg/controller/cronjobsource/reconcile.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,6 +45,10 @@ type reconciler struct {
 
 func (r *reconciler) InjectClient(c client.Client) error {
 	r.client = c
+	return nil
+}
+
+func (r *reconciler) InjectConfig(c *rest.Config) error {
 	return nil
 }
 
@@ -70,7 +75,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 		return src, err
 	}
 	src.Status.MarkSchedule()
-	sinkURI, err := sinks.GetSinkURI(ctx, r.client, src.Spec.Sink, src.Namespace)
+	sinkURI, err := sinks.GetSinkURI_CR(ctx, r.client, src.Spec.Sink, src.Namespace)
 	if err != nil {
 		src.Status.MarkNoSink("NotFound", "")
 		return src, err

--- a/pkg/controller/kuberneteseventsource/provider.go
+++ b/pkg/controller/kuberneteseventsource/provider.go
@@ -22,6 +22,8 @@ import (
 
 	sourcesv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -38,6 +40,7 @@ const (
 // reconciler reconciles a KubernetesEventSource object
 type reconciler struct {
 	client.Client
+	dynamicClient       dynamic.Interface
 	recorder            record.EventRecorder
 	scheme              *runtime.Scheme
 	receiveAdapterImage string
@@ -90,4 +93,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	return nil
+}
+
+func (r *reconciler) InjectConfig(c *rest.Config) error {
+	var err error
+	r.dynamicClient, err = dynamic.NewForConfig(c)
+	return err
 }

--- a/pkg/controller/sdk/provider.go
+++ b/pkg/controller/sdk/provider.go
@@ -18,18 +18,19 @@ package sdk
 
 import (
 	"context"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 type KnativeReconciler interface {
 	Reconcile(ctx context.Context, object runtime.Object) (runtime.Object, error)
-	inject.Client
+	InjectClient(c client.Client) error
+	InjectConfig(c *rest.Config) error
 }
 
 type Provider struct {

--- a/pkg/controller/sinks/sinks.go
+++ b/pkg/controller/sinks/sinks.go
@@ -16,46 +16,6 @@ limitations under the License.
 
 package sinks
 
-import (
-	"context"
-	"fmt"
-
-	"github.com/knative/pkg/apis/duck"
-	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
 // GetSinkURI retrieves the sink URI from the object referenced by the given
 // ObjectReference.
-func GetSinkURI(ctx context.Context, c client.Client, sink *corev1.ObjectReference, namespace string) (string, error) {
-	if sink == nil {
-		return "", fmt.Errorf("sink ref is nil")
-	}
-
-	u := &unstructured.Unstructured{}
-	u.SetGroupVersionKind(sink.GroupVersionKind())
-	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: sink.Name}, u)
-	if err != nil {
-		return "", err
-	}
-
-	objIdentifier := fmt.Sprintf("\"%s/%s\" (%s)", u.GetNamespace(), u.GetName(), u.GroupVersionKind())
-
-	t := duckv1alpha1.AddressableType{}
-	err = duck.FromUnstructured(u, &t)
-	if err != nil {
-		return "", fmt.Errorf("failed to deserialize sink %s: %v", objIdentifier, err)
-	}
-
-	if t.Status.Address == nil {
-		return "", fmt.Errorf("sink %s does not contain address", objIdentifier)
-	}
-
-	if t.Status.Address.Hostname == "" {
-		return "", fmt.Errorf("sink %s contains an empty hostname", objIdentifier)
-	}
-
-	return fmt.Sprintf("http://%s/", t.Status.Address.Hostname), nil
-}
+var GetSinkURI = GetSinkURI_DC

--- a/pkg/controller/sinks/sinks_cr.go
+++ b/pkg/controller/sinks/sinks_cr.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sinks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/knative/pkg/apis/duck"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetSinkURI_CR retrieves the sink URI from the object referenced by the given
+// ObjectReference.
+func GetSinkURI_CR(ctx context.Context, c client.Client, sink *corev1.ObjectReference, namespace string) (string, error) {
+	if sink == nil {
+		return "", fmt.Errorf("sink ref is nil")
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(sink.GroupVersionKind())
+	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: sink.Name}, u)
+	if err != nil {
+		return "", err
+	}
+
+	objIdentifier := fmt.Sprintf("\"%s/%s\" (%s)", u.GetNamespace(), u.GetName(), u.GroupVersionKind())
+
+	t := duckv1alpha1.AddressableType{}
+	err = duck.FromUnstructured(u, &t)
+	if err != nil {
+		return "", fmt.Errorf("failed to deserialize sink %s: %v", objIdentifier, err)
+	}
+
+	if t.Status.Address == nil {
+		return "", fmt.Errorf("sink %s does not contain address", objIdentifier)
+	}
+
+	if t.Status.Address.Hostname == "" {
+		return "", fmt.Errorf("sink %s contains an empty hostname", objIdentifier)
+	}
+
+	return fmt.Sprintf("http://%s/", t.Status.Address.Hostname), nil
+}

--- a/pkg/controller/sinks/sinks_cr_test.go
+++ b/pkg/controller/sinks/sinks_cr_test.go
@@ -50,7 +50,7 @@ func init() {
 	duckv1alpha1.AddToScheme(scheme.Scheme)
 }
 
-func TestGetSinkURI(t *testing.T) {
+func TestGetSinkURI_CR(t *testing.T) {
 	testCases := map[string]struct {
 		objects   []runtime.Object
 		namespace string
@@ -100,7 +100,7 @@ func TestGetSinkURI(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			ctx := context.Background()
 			client := fake.NewFakeClient(tc.objects...)
-			uri, gotErr := GetSinkURI(ctx, client, tc.ref, tc.namespace)
+			uri, gotErr := GetSinkURI_CR(ctx, client, tc.ref, tc.namespace)
 			if gotErr != nil {
 				if tc.wantErr != nil {
 					if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {

--- a/pkg/controller/sinks/sinks_dc.go
+++ b/pkg/controller/sinks/sinks_dc.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sinks
+
+import (
+	"fmt"
+
+	duckapis "github.com/knative/pkg/apis"
+	"github.com/knative/pkg/apis/duck"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// GetSinkURI_DC retrieves the sink URI from the object referenced by the given
+// ObjectReference.
+func GetSinkURI_DC(dc dynamic.Interface, sink *corev1.ObjectReference, namespace string) (string, error) {
+	if sink == nil {
+		return "", fmt.Errorf("sink ref is nil")
+	}
+
+	obj, err := fetchObjectReference(dc, sink, namespace)
+	if err != nil {
+		return "", err
+	}
+	t := duckv1alpha1.AddressableType{}
+	err = duck.FromUnstructured(obj, &t)
+	if err != nil {
+		return "", fmt.Errorf("failed to deserialize sink: %v", err)
+	}
+
+	if t.Status.Address == nil {
+		return "", fmt.Errorf("sink does not contain address")
+	}
+
+	if t.Status.Address.Hostname == "" {
+		return "", fmt.Errorf("sink contains an empty hostname")
+	}
+
+	return fmt.Sprintf("http://%s/", t.Status.Address.Hostname), nil
+}
+
+func fetchObjectReference(dc dynamic.Interface, ref *corev1.ObjectReference, namespace string) (duck.Marshalable, error) {
+	resourceClient, err := createResourceInterface(dc, ref, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return resourceClient.Get(ref.Name, metav1.GetOptions{})
+}
+
+func createResourceInterface(dc dynamic.Interface, ref *corev1.ObjectReference, namespace string) (dynamic.ResourceInterface, error) {
+	rc := dc.Resource(duckapis.KindToResource(ref.GroupVersionKind()))
+	if rc == nil {
+		return nil, fmt.Errorf("failed to create dynamic client resource")
+	}
+	return rc.Namespace(namespace), nil
+}

--- a/pkg/controller/sinks/sinks_dc_test.go
+++ b/pkg/controller/sinks/sinks_dc_test.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sinks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func init() {
+	// Add types to scheme
+	duckv1alpha1.AddToScheme(scheme.Scheme)
+}
+
+func TestGetSinkURI_DC(t *testing.T) {
+	testCases := map[string]struct {
+		dc        dynamic.Interface
+		namespace string
+		want      string
+		wantErr   error
+		ref       *corev1.ObjectReference
+	}{
+		"happy": {
+			dc: getDynamicClient(scheme.Scheme,
+				[]runtime.Object{
+					// unaddressable resource
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "duck.knative.dev/v1alpha1",
+							"kind":       "Sink",
+							"metadata": map[string]interface{}{
+								"namespace": "default",
+								"name":      "foo",
+							},
+							"status": map[string]interface{}{
+								"address": map[string]interface{}{
+									"hostname": "example.com",
+								},
+							},
+						},
+					},
+				}),
+			namespace: "default",
+			ref: &corev1.ObjectReference{
+				Kind:       "Sink",
+				Name:       "foo",
+				APIVersion: "duck.knative.dev/v1alpha1",
+			},
+			want: "http://example.com/",
+		},
+		"nil hostname": {
+			dc: getDynamicClient(scheme.Scheme,
+				[]runtime.Object{
+					// unaddressable resource
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "duck.knative.dev/v1alpha1",
+							"kind":       "Sink",
+							"metadata": map[string]interface{}{
+								"namespace": "default",
+								"name":      "foo",
+							},
+							"status": map[string]interface{}{
+								"address": map[string]interface{}{
+									"hostname": nil,
+								},
+							},
+						},
+					},
+				}),
+			namespace: "default",
+			ref: &corev1.ObjectReference{
+				Kind:       "Sink",
+				Name:       "foo",
+				APIVersion: "duck.knative.dev/v1alpha1",
+			},
+			wantErr: fmt.Errorf(`sink contains an empty hostname`),
+		},
+		"nil sink": {
+			dc: getDynamicClient(scheme.Scheme,
+				[]runtime.Object{
+					// unaddressable resource
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "duck.knative.dev/v1alpha1",
+							"kind":       "Sink",
+							"metadata": map[string]interface{}{
+								"namespace": "default",
+								"name":      "foo",
+							},
+							"status": map[string]interface{}{
+								"address": map[string]interface{}{
+									"hostname": nil,
+								},
+							},
+						},
+					},
+				}),
+			namespace: "default",
+			ref:       nil,
+			wantErr:   fmt.Errorf(`sink ref is nil`),
+		},
+		"notSink": {
+			dc: getDynamicClient(scheme.Scheme,
+				[]runtime.Object{
+					// unaddressable resource
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "duck.knative.dev/v1alpha1",
+							"kind":       "KResource",
+							"metadata": map[string]interface{}{
+								"namespace": "default",
+								"name":      "foo",
+							},
+						},
+					},
+				}),
+			namespace: "default",
+			ref: &corev1.ObjectReference{
+				Kind:       "KResource",
+				Name:       "foo",
+				APIVersion: "duck.knative.dev/v1alpha1",
+			},
+			wantErr: fmt.Errorf(`sink does not contain address`),
+		},
+		"notFound": {
+			dc: getDynamicClient(scheme.Scheme,
+				nil),
+			namespace: "default",
+			ref: &corev1.ObjectReference{
+				Kind:       "KResource",
+				Name:       "foo",
+				APIVersion: "duck.knative.dev/v1alpha1",
+			},
+			wantErr: fmt.Errorf(`kresources.duck.knative.dev "foo" not found`),
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			uri, gotErr := GetSinkURI_DC(tc.dc, tc.ref, tc.namespace)
+			if gotErr != nil {
+				if tc.wantErr != nil {
+					if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
+						t.Errorf("%s: unexpected error (-want, +got) = %v", n, diff)
+					}
+				} else {
+					t.Errorf("%s: unexpected error %v", n, gotErr.Error())
+				}
+			}
+			if gotErr == nil {
+				got := uri
+				if diff := cmp.Diff(tc.want, got); diff != "" {
+					t.Errorf("%s: unexpected object (-want, +got) = %v", n, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestFetchObjectReference(t *testing.T) {
+	testCases := map[string]struct {
+		dc        dynamic.Interface
+		namespace string
+		want      *unstructured.Unstructured
+		wantErr   error
+		ref       *corev1.ObjectReference
+	}{
+		"happy": {
+			dc: getDynamicClient(scheme.Scheme,
+				[]runtime.Object{
+					// unaddressable resource
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "duck.knative.dev/v1alpha1",
+							"kind":       "KResource",
+							"metadata": map[string]interface{}{
+								"namespace": "default",
+								"name":      "foo",
+							},
+						},
+					},
+				}),
+			ref: &corev1.ObjectReference{
+				Kind:       "KResource",
+				Name:       "foo",
+				Namespace:  "default",
+				APIVersion: "duck.knative.dev/v1alpha1",
+			},
+			namespace: "default",
+			want: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "duck.knative.dev/v1alpha1",
+					"kind":       "KResource",
+					"metadata": map[string]interface{}{
+						"namespace": "default",
+						"name":      "foo",
+					},
+				},
+			},
+			wantErr: error(nil),
+		},
+		"dynamicClientError": {
+			dc: getErrorClient(),
+			ref: &corev1.ObjectReference{
+				Kind:       "Kind",
+				Name:       "Name",
+				APIVersion: "api/version",
+			},
+			namespace: "default",
+			wantErr:   fmt.Errorf("failed to create dynamic client resource"),
+		},
+		"errorNotFound": {
+			dc: getDynamicClient(nil, nil),
+			ref: &corev1.ObjectReference{
+				Kind:       "Kind",
+				Name:       "Name",
+				APIVersion: "api/version",
+			},
+			namespace: "default",
+			wantErr:   fmt.Errorf(`kinds.api "Name" not found`),
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			obj, gotErr := fetchObjectReference(tc.dc, tc.ref, tc.namespace)
+
+			if tc.wantErr != gotErr {
+				if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
+					t.Errorf("unexpected error (-want, +got) = %v", diff)
+				}
+			}
+
+			var want []byte
+			var got []byte
+
+			if gotErr == nil && obj != nil {
+				got, _ = obj.MarshalJSON()
+			}
+			if tc.want != nil {
+				want, _ = tc.want.MarshalJSON()
+			}
+
+			if diff := cmp.Diff(string(want), string(got)); diff != "" {
+				t.Errorf("unexpected object (-want, +got) = %v", diff)
+			}
+		})
+	}
+
+}
+
+func TestCreateResourceInterface(t *testing.T) {
+	testCases := map[string]struct {
+		dc        dynamic.Interface
+		namespace string
+		wantNil   bool
+		wantErr   error
+		ref       *corev1.ObjectReference
+	}{
+		"happy": {
+			dc: getDynamicClient(nil, nil),
+			ref: &corev1.ObjectReference{
+				Kind:       "Kind",
+				Name:       "Name",
+				APIVersion: "api/version",
+			},
+			namespace: "default",
+			wantErr:   error(nil),
+			wantNil:   false,
+		},
+		"error": {
+			dc: getErrorClient(),
+			ref: &corev1.ObjectReference{
+				Kind:       "Kind",
+				Name:       "Name",
+				APIVersion: "api/version",
+			},
+			namespace: "default",
+			wantErr:   fmt.Errorf("failed to create dynamic client resource"),
+			wantNil:   true,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			got, gotErr := createResourceInterface(tc.dc, tc.ref, tc.namespace)
+
+			if tc.wantErr != gotErr {
+				if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
+					t.Errorf("unexpected error (-want, +got) = %v", diff)
+				}
+			}
+
+			if (got != nil) == tc.wantNil {
+				t.Errorf("%s: unexpected interface wanted nil %v, got %v", n, tc.wantNil, got == nil)
+			}
+		})
+	}
+}
+
+// GetDynamicClient returns the mockDynamicClient to use for this test case.
+func getDynamicClient(scheme *runtime.Scheme, objs []runtime.Object) dynamic.Interface {
+	if scheme == nil {
+		return dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), objs...)
+	}
+	return dynamicfake.NewSimpleDynamicClient(scheme, objs...)
+}
+
+func getErrorClient() dynamic.Interface {
+	return &errorClient{}
+}
+
+type errorClient struct{}
+
+var _ dynamic.Interface = &errorClient{}
+
+func (c *errorClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return nil
+}


### PR DESCRIPTION
This is an attempt to track down the issues caused by https://github.com/knative/eventing/issues/718.

It creates two versions of GetSinkURI, pre-#137 (dynamic clients) and post-#137 (controller-runtime unstructured client). The older sources have been reverted to use the dynamic clients version. The cronjobsource and awssqssource never had dynamic client versions, so they still use the controller-runtime unstructured client version.

If the eventing e2e tests pass with this change, then it seems clear that #137 caused them.
