### PR TITLE
Label source CRDs eventing.knative.dev/source=true

### DIFF
--- a/config/awssqs/kustomization.yaml
+++ b/config/awssqs/kustomization.yaml
@@ -16,4 +16,5 @@ resources:
 
 patches:
   - conditions_patch.yaml
+  - label_patch.yaml
   - env_patch.yaml

--- a/config/awssqs/label_patch.yaml
+++ b/config/awssqs/label_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: awssqssources.sources.eventing.knative.dev
+  labels:
+    eventing.knative.dev/source: "true"

--- a/config/default-awssqs.yaml
+++ b/config/default-awssqs.yaml
@@ -11,6 +11,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: awssqssources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev
@@ -86,6 +87,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: containersources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev
@@ -166,6 +168,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: cronjobsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev
@@ -241,6 +244,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: githubsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev
@@ -369,6 +373,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: kuberneteseventsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -11,6 +11,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: containersources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev
@@ -91,6 +92,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: cronjobsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev
@@ -166,6 +168,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: githubsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev
@@ -294,6 +297,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: kuberneteseventsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/config/default/containersource_label_patch.yaml
+++ b/config/default/containersource_label_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: containersources.sources.eventing.knative.dev
+  labels:
+    eventing.knative.dev/source: "true"

--- a/config/default/cronjobsource_label_patch.yaml
+++ b/config/default/cronjobsource_label_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cronjobsources.sources.eventing.knative.dev
+  labels:
+    eventing.knative.dev/source: "true"

--- a/config/default/githubsource_label_patch.yaml
+++ b/config/default/githubsource_label_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: githubsources.sources.eventing.knative.dev
+  labels:
+    eventing.knative.dev/source: "true"

--- a/config/default/kuberneteseventsource_label_patch.yaml
+++ b/config/default/kuberneteseventsource_label_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kuberneteseventsources.sources.eventing.knative.dev
+  labels:
+    eventing.knative.dev/source: "true"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -8,16 +8,20 @@ namespace: knative-sources
 # markers ("---").
 resources:
 - ../crds/sources_v1alpha1_containersource.yaml
-- ../crds/sources_v1alpha1_kuberneteseventsource.yaml
-- ../crds/sources_v1alpha1_githubsource.yaml
 - ../crds/sources_v1alpha1_cronjobsource.yaml
+- ../crds/sources_v1alpha1_githubsource.yaml
+- ../crds/sources_v1alpha1_kuberneteseventsource.yaml
 - ../rbac/rbac_role.yaml
 - ../rbac/rbac_role_binding.yaml
 - ../manager/manager.yaml
 
 patches:
 - manager_image_patch.yaml
+- containersource_label_patch.yaml
+- cronjobsource_label_patch.yaml
+- githubsource_label_patch.yaml
+- kuberneteseventsource_label_patch.yaml
 - containersource_conditions_patch.yaml
-- kuberneteseventsource_conditions_patch.yaml
-- githubsource_conditions_patch.yaml
 - cronjobsource_conditions_patch.yaml
+- githubsource_conditions_patch.yaml
+- kuberneteseventsource_conditions_patch.yaml

--- a/contrib/gcppubsub/config/default-gcppubsub.yaml
+++ b/contrib/gcppubsub/config/default-gcppubsub.yaml
@@ -4,6 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
+    eventing.knative.dev/source: "true"
   name: gcppubsubsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/contrib/gcppubsub/config/kustomization.yaml
+++ b/contrib/gcppubsub/config/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
 
 patches:
   - conditions_patch.yaml
+  - label_patch.yaml
   - rbac_role_binding_patch.yaml

--- a/contrib/gcppubsub/config/label_patch.yaml
+++ b/contrib/gcppubsub/config/label_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: gcppubsubsources.sources.eventing.knative.dev
+  labels:
+    eventing.knative.dev/source: "true"


### PR DESCRIPTION
Supersedes #183.
Fixes #176.

@vaikas-google I think you said you were having trouble with #183 so I thought I'd give it a try; hope you don't mind :)

Sources are using controller-tools to generate their CRD yamls via annotations, but controller-tools doesn't support labeling CRDs yet. Use kustomize patches to add labels instead. There's probably a prettier way to do this but this was the quickest.

## Proposed Changes

  * Add label eventing.knative.dev/source: "true"

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Each source CRD is now labeled with:
    eventing.knative.dev/source: "true"
which means you can find list of available sources with:
 kubectl get crds -l "eventing.knative.dev/source=true"
```