### PR TITLE
Replace repeated YAML lists with anchors and aliases. 

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -26,7 +26,7 @@ rules:
   - cronjobsources
   - githubsources
   - kuberneteseventsources
-  verbs:
+  verbs: &everything
   - get
   - list
   - watch
@@ -34,7 +34,7 @@ rules:
   - update
   - patch
   - delete
-  
+
 # Source statuses update
 - apiGroups:
   - sources.eventing.knative.dev
@@ -54,59 +54,35 @@ rules:
   - apps
   resources:
   - deployments
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  verbs: *everything
 
 # Channels read
 - apiGroups:
   - eventing.knative.dev
   resources:
   - channels
-  verbs:
+  verbs: &readOnly
   - get
   - list
   - watch
-  
+
 # Knative Services admin
 - apiGroups:
   - serving.knative.dev
   resources:
   - services
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  verbs: *everything
 
 # Secrets read
 - apiGroups:
   - ""
   resources:
   - secrets
-  verbs:
-  - get
-  - list
-  - watch
+  verbs: *readOnly
 
 # Events admin
 - apiGroups:
   - ""
   resources:
   - events
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  verbs: *everything

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -21,13 +21,12 @@ metadata:
     control-plane: controller-manager
 spec:
   selector:
-    matchLabels:
+    matchLabels: &labels
       control-plane: controller-manager
   serviceName: controller-manager
   template:
     metadata:
-      labels:
-        control-plane: controller-manager
+      labels: *labels
     spec:
       serviceAccountName: controller-manager
       containers:

--- a/contrib/gcppubsub/config/201-clusterrole.yaml
+++ b/contrib/gcppubsub/config/201-clusterrole.yaml
@@ -22,7 +22,7 @@ rules:
   - sources.eventing.knative.dev
   resources:
   - gcppubsubsources
-  verbs:
+  verbs: &everything
   - get
   - list
   - watch
@@ -44,20 +44,13 @@ rules:
   - apps
   resources:
   - deployments
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  verbs: *everything
 
 - apiGroups:
   - ""
   resources:
   - secrets
-  verbs:
+  verbs: &readOnly
   - get
   - list
   - watch
@@ -66,17 +59,11 @@ rules:
   - eventing.knative.dev
   resources:
   - channels
-  verbs:
-  - get
-  - list
-  - watch
+  verbs: *readOnly
 
 - apiGroups:
   - serving.knative.dev
   resources:
   - services
   - routes
-  verbs:
-  - get
-  - list
-  - watch
+  verbs: *readOnly

--- a/contrib/gcppubsub/config/500-controller.yaml
+++ b/contrib/gcppubsub/config/500-controller.yaml
@@ -21,13 +21,12 @@ metadata:
     control-plane: gcppubsub-controller-manager
 spec:
   selector:
-    matchLabels:
+    matchLabels: &labels
       control-plane: gcppubsub-controller-manager
   serviceName: gcppubsub-controller-manager
   template:
     metadata:
-      labels:
-        control-plane: gcppubsub-controller-manager
+      labels: *labels
     spec:
       serviceAccountName: gcppubsub-controller-manager
       containers:


### PR DESCRIPTION
Fixes #194

## Proposed Changes

  * Replace repeated YAML lists with anchors and aliases.
      - Forces `Deployment`s to match the labels that are generated.
      - Slightly easier to read RBAC

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```