### PR TITLE
Change Signature of KnativeReconciler.Reconcile

### DIFF
--- a/pkg/controller/containersource/reconcile_test.go
+++ b/pkg/controller/containersource/reconcile_test.go
@@ -584,7 +584,8 @@ func TestObjectNotContainerSource(t *testing.T) {
 		APIVersion: unaddressableAPIVersion,
 	}
 
-	got, gotErr := r.Reconcile(context.TODO(), obj)
+	got := obj.DeepCopy()
+	gotErr := r.Reconcile(context.TODO(), got)
 	var want runtime.Object = obj
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected returned object (-want, +got) = %v", diff)
@@ -601,7 +602,8 @@ func TestObjectHasDeleteTimestamp(t *testing.T) {
 
 	now := metav1.Now()
 	obj.DeletionTimestamp = &now
-	got, gotErr := r.Reconcile(context.TODO(), obj)
+	got := obj.DeepCopy()
+	gotErr := r.Reconcile(context.TODO(), got)
 	var want runtime.Object = obj
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected returned object (-want, +got) = %v", diff)

--- a/pkg/controller/githubsource/reconcile.go
+++ b/pkg/controller/githubsource/reconcile.go
@@ -55,20 +55,20 @@ type reconciler struct {
 // Reconcile reads that state of the cluster for a GitHubSource
 // object and makes changes based on the state read and what is in the
 // GitHubSource.Spec
-func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runtime.Object, error) {
+func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) error {
 	logger := logging.FromContext(ctx)
 
 	source, ok := object.(*sourcesv1alpha1.GitHubSource)
 	if !ok {
 		logger.Errorf("could not find github source %v\n", object)
-		return object, nil
+		return nil
 	}
 
 	// See if the source has been deleted
 	accessor, err := meta.Accessor(source)
 	if err != nil {
 		logger.Warnf("Failed to get metadata accessor: %s", zap.Error(err))
-		return object, err
+		return err
 	}
 
 	var reconcileErr error
@@ -78,7 +78,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) (runt
 		reconcileErr = r.finalize(ctx, source)
 	}
 
-	return source, reconcileErr
+	return reconcileErr
 }
 
 func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitHubSource) error {

--- a/pkg/controller/githubsource/reconcile_test.go
+++ b/pkg/controller/githubsource/reconcile_test.go
@@ -678,7 +678,8 @@ func TestObjectNotGitHubSource(t *testing.T) {
 		APIVersion: unaddressableAPIVersion,
 	}
 
-	got, gotErr := r.Reconcile(context.TODO(), obj)
+	got := obj.DeepCopy()
+	gotErr := r.Reconcile(context.TODO(), got)
 	var want runtime.Object = obj
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected returned object (-want, +got) = %v", diff)

--- a/pkg/controller/sdk/provider.go
+++ b/pkg/controller/sdk/provider.go
@@ -28,7 +28,7 @@ import (
 )
 
 type KnativeReconciler interface {
-	Reconcile(ctx context.Context, object runtime.Object) (runtime.Object, error)
+	Reconcile(ctx context.Context, object runtime.Object) error
 	inject.Client
 }
 

--- a/pkg/controller/sdk/reconciler.go
+++ b/pkg/controller/sdk/reconciler.go
@@ -65,6 +65,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
+	// Don't modify the cache's copy
 	obj := original.DeepCopyObject()
 
 	// Reconcile this copy of the Source and then write back any status

--- a/pkg/controller/sdk/reconciler.go
+++ b/pkg/controller/sdk/reconciler.go
@@ -51,9 +51,9 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	logger.Infof("Reconciling %s %v", r.provider.Parent.GetObjectKind(), request)
 
-	obj := r.provider.Parent.DeepCopyObject()
+	original := r.provider.Parent.DeepCopyObject()
 
-	err := r.client.Get(context.TODO(), request.NamespacedName, obj)
+	err := r.client.Get(context.TODO(), request.NamespacedName, original)
 
 	if errors.IsNotFound(err) {
 		logger.Errorf("could not find %s %v\n", r.provider.Parent.GetObjectKind(), request)
@@ -65,11 +65,11 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	original := obj.DeepCopyObject()
+	obj := original.DeepCopyObject()
 
 	// Reconcile this copy of the Source and then write back any status
 	// updates regardless of whether the reconcile error out.
-	obj, reconcileErr := r.provider.Reconciler.Reconcile(ctx, obj)
+	reconcileErr := r.provider.Reconciler.Reconcile(ctx, obj)
 	if reconcileErr != nil {
 		logger.Warnf("Failed to reconcile %s: %v", r.provider.Parent.GetObjectKind(), reconcileErr)
 	}

--- a/pkg/controller/testing/table.go
+++ b/pkg/controller/testing/table.go
@@ -153,7 +153,7 @@ func (tc *TestCase) Reconcile(c client.Client, r sdk.KnativeReconciler) (runtime
 		return nil, nil
 	}
 
-	return r.Reconcile(context.TODO(), obj)
+	return obj, r.Reconcile(context.TODO(), obj)
 }
 
 // VerifyErr verifies that the given error returned from Reconcile is the error


### PR DESCRIPTION
Fixing a minor bug with the reconciler editing the cache and changing the signature of Reconcile to make it more clear this was a bug.

## Proposed Changes

  * Change Signature of KnativeReconciler.Reconcile to `Reconcile(ctx context.Context, object runtime.Object) error`

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```