### PR TITLE
golang format tools

### DIFF
--- a/cmd/cronjob_receive_adapter/main.go
+++ b/cmd/cronjob_receive_adapter/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/pkg/signals"
 	"log"
 	"os"
+
+	"github.com/knative/pkg/signals"
 
 	"github.com/knative/eventing-sources/pkg/adapter/cronjobevents"
 	"go.uber.org/zap"

--- a/cmd/heartbeats/main.go
+++ b/cmd/heartbeats/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	"github.com/mgutz/logxi/v1"
 	"strconv"
 	"time"
+
+	log "github.com/mgutz/logxi/v1"
 
 	"github.com/knative/pkg/cloudevents"
 )

--- a/cmd/websocketsource/main.go
+++ b/cmd/websocketsource/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
+	"log"
+
 	"github.com/gorilla/websocket"
 	"github.com/knative/pkg/cloudevents"
-	"log"
 )
 
 var (

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -19,6 +19,7 @@ package cronjobevents
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/robfig/cron"
 
 	"github.com/knative/pkg/cloudevents"

--- a/pkg/adapter/cronjobevents/adapter_test.go
+++ b/pkg/adapter/cronjobevents/adapter_test.go
@@ -16,12 +16,13 @@ package cronjobevents
 import (
 	"context"
 	"encoding/json"
-	"github.com/google/go-cmp/cmp"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestStart_ServeHTTP(t *testing.T) {

--- a/pkg/adapter/github/adapter.go
+++ b/pkg/adapter/github/adapter.go
@@ -18,13 +18,14 @@ package github
 
 import (
 	"fmt"
+	"log"
+	"net/http"
+
 	"github.com/google/uuid"
 	sourcesv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/pkg/cloudevents"
-	"gopkg.in/go-playground/webhooks.v3"
+	webhooks "gopkg.in/go-playground/webhooks.v3"
 	gh "gopkg.in/go-playground/webhooks.v3/github"
-	"log"
-	"net/http"
 )
 
 const (

--- a/pkg/adapter/github/adapter_test.go
+++ b/pkg/adapter/github/adapter_test.go
@@ -20,15 +20,16 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/knative/pkg/cloudevents"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"gopkg.in/go-playground/webhooks.v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/cloudevents"
+
+	webhooks "gopkg.in/go-playground/webhooks.v3"
 	gh "gopkg.in/go-playground/webhooks.v3/github"
 )
 

--- a/pkg/adapter/kubernetesevents/adapter.go
+++ b/pkg/adapter/kubernetesevents/adapter.go
@@ -19,6 +19,7 @@ package kubernetesevents
 import (
 	"context"
 	"fmt"
+
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
 

--- a/pkg/reconciler/cronjobsource/cronjobsource.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource.go
@@ -29,7 +29,7 @@ import (
 	"github.com/knative/pkg/logging"
 	"github.com/robfig/cron"
 	"go.uber.org/zap"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
