### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/awssqssource/awssqssource.go
+++ b/pkg/reconciler/awssqssource/awssqssource.go
@@ -28,7 +28,7 @@ import (
 	"github.com/knative/eventing-sources/pkg/reconciler/awssqssource/resources"
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
