### PR TITLE
Upgrade `knative/pkg` to latest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -347,7 +347,7 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:8135fbad3c8ad337d38be5ea27393ad98b3b14f6d325f9d26845aa157f4865a3"
+  digest = "1:4cffc82f78980821bff4a0cb9874b93b87214a39e997639ce3aa67ed931c3b8d"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -362,7 +362,7 @@
     "signals",
   ]
   pruneopts = "NUT"
-  revision = "cc3cc546fee76ddbb55cdb2c90e0a2871c9eef78"
+  revision = "1982208dd91a4cc4fea9612e4e72fb109c77ab22"
 
 [[projects]]
   digest = "1:5d4ddd664e297c3453b40e94e69ea3d1aaa8efbff3c4fe0d892f9a588c499770"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,8 +38,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-01-29
-  revision = "cc3cc546fee76ddbb55cdb2c90e0a2871c9eef78"
+  # HEAD as of 2019-02-12
+  revision = "1982208dd91a4cc4fea9612e4e72fb109c77ab22"
 
 [[override]]
   name = "k8s.io/api"

--- a/cmd/heartbeats_receiver/main.go
+++ b/cmd/heartbeats_receiver/main.go
@@ -31,8 +31,8 @@ type Heartbeat struct {
 }
 
 func handler(ctx context.Context, hb *Heartbeat) {
-	metadata := cloudevents.FromContext(ctx)
-	log.Printf("[%s] %s %s: %d,%q", metadata.EventTime.Format(time.RFC3339), metadata.ContentType, metadata.Source, hb.Sequence, hb.Label)
+	metadata := cloudevents.FromContext(ctx).AsV02()
+	log.Printf("[%s] %s %s: %d,%q", metadata.Time.Format(time.RFC3339), metadata.Type, metadata.Source, hb.Sequence, hb.Label)
 }
 
 func main() {

--- a/contrib/gcppubsub/pkg/adapter/adapter.go
+++ b/contrib/gcppubsub/pkg/adapter/adapter.go
@@ -95,7 +95,7 @@ func (a *Adapter) postMessage(ctx context.Context, logger *zap.SugaredLogger, m 
 		logger.Infof("overriding the cloud event type with %q", et)
 	}
 
-	event := cloudevents.EventContext{
+	event := cloudevents.V01EventContext{
 		CloudEventsVersion: cloudevents.CloudEventsVersion,
 		EventType:          et,
 		EventID:            m.ID(),

--- a/pkg/adapter/github/adapter_test.go
+++ b/pkg/adapter/github/adapter_test.go
@@ -452,7 +452,8 @@ func (tc *testCase) runner(t *testing.T, ra Adapter) func(t *testing.T) {
 }
 
 func (tc *testCase) handleRequest(req *http.Request) (*http.Response, error) {
-	cloudEvent, err := cloudevents.Binary.FromRequest(nil, req)
+	rawContext, err := cloudevents.Binary.FromRequest(nil, req)
+	cloudEvent := rawContext.AsV01()
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error decoding cloudevent: %s", err)
 	}
@@ -522,8 +523,8 @@ func TestHandleEvent(t *testing.T) {
 			"ce-eventtime":          {"2019-01-29T09:35:10.69383396-08:00"},
 			"ce-eventtype":          {"dev.knative.source.github.pull_request"},
 			"ce-source":             {"http://github.com/a/b"},
-			"ce-x-github-delivery":  {"12345"},
-			"ce-x-github-event":     {"pull_request"},
+			"ce-x-github-delivery":  {`"12345"`},
+			"ce-x-github-event":     {`"pull_request"`},
 
 			"content-type": {"application/json"},
 		},

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/condition_set.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/condition_set.go
@@ -280,7 +280,7 @@ func (r conditionsImpl) MarkUnknown(t ConditionType, reason, messageFormat strin
 			// Double check that the happy condition is also false.
 			happy := r.GetCondition(r.happy)
 			if !happy.IsFalse() {
-				r.MarkFalse(r.happy, reason, messageFormat, messageA)
+				r.MarkFalse(r.happy, reason, messageFormat, messageA...)
 			}
 			return
 		}

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
@@ -47,8 +47,10 @@ type ConditionSeverity string
 
 const (
 	// ConditionSeverityError specifies that a failure of a condition type
-	// should be viewed as an error.
-	ConditionSeverityError ConditionSeverity = "Error"
+	// should be viewed as an error.  As "Error" is the default for conditions
+	// we use the empty string (coupled with omitempty) to avoid confusion in
+	// the case where the condition is in state "True" (aka nothing is wrong).
+	ConditionSeverityError ConditionSeverity = ""
 	// ConditionSeverityWarning specifies that a failure of a condition type
 	// should be viewed as a warning, but that things could still work.
 	ConditionSeverityWarning ConditionSeverity = "Warning"

--- a/vendor/github.com/knative/pkg/apis/field_error.go
+++ b/vendor/github.com/knative/pkg/apis/field_error.go
@@ -192,7 +192,7 @@ func asKey(key string) string {
 //   err([0]).ViaField(bar).ViaField(foo) -> foo.bar.[0] converts to foo.bar[0]
 //   err(bar).ViaIndex(0).ViaField(foo) -> foo.[0].bar converts to foo[0].bar
 //   err(bar).ViaField(foo).ViaIndex(0) -> [0].foo.bar converts to [0].foo.bar
-//   err(bar).ViaIndex(0).ViaIndex[1].ViaField(foo) -> foo.[1].[0].bar converts to foo[1][0].bar
+//   err(bar).ViaIndex(0).ViaIndex(1).ViaField(foo) -> foo.[1].[0].bar converts to foo[1][0].bar
 func flatten(path []string) string {
 	var newPath []string
 	for _, part := range path {
@@ -298,6 +298,12 @@ func ErrDisallowedFields(fieldPaths ...string) *FieldError {
 		Message: "must not set the field(s)",
 		Paths:   fieldPaths,
 	}
+}
+
+// ErrInvalidArrayValue consturcts a FieldError for a repetetive `field`
+// at `index` that has received an invalid string value.
+func ErrInvalidArrayValue(value, field string, index int) *FieldError {
+	return ErrInvalidValue(value, CurrentField).ViaFieldIndex(field, index)
 }
 
 // ErrInvalidValue constructs a FieldError for a field that has received an

--- a/vendor/github.com/knative/pkg/apis/interfaces.go
+++ b/vendor/github.com/knative/pkg/apis/interfaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apis
 
 import (
+	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -46,4 +47,9 @@ type Listable interface {
 	runtime.Object
 
 	GetListType() runtime.Object
+}
+
+// Annotatable indicates that a particular type applies various annotations.
+type Annotatable interface {
+	AnnotateUserInfo(previous Annotatable, ui *authenticationv1.UserInfo)
 }

--- a/vendor/github.com/knative/pkg/cloudevents/builder.go
+++ b/vendor/github.com/knative/pkg/cloudevents/builder.go
@@ -62,7 +62,7 @@ func (b *Builder) Build(target string, data interface{}, overrides ...SendContex
 		return nil, fmt.Errorf("Build was called with more than one override")
 	}
 
-	var overridesV01 *V01EventContext = nil
+	var overridesV01 *V01EventContext
 	if len(overrides) == 1 {
 		switch t := overrides[0].(type) {
 		case V01EventContext:

--- a/vendor/github.com/knative/pkg/cloudevents/event.go
+++ b/vendor/github.com/knative/pkg/cloudevents/event.go
@@ -53,38 +53,58 @@ type EventContext = V01EventContext
 // HTTPMarshaller implements a scheme for decoding CloudEvents over HTTP.
 // Implementations are Binary, Structured, and Any
 type HTTPMarshaller interface {
-	FromRequest(data interface{}, r *http.Request) (*EventContext, error)
+	FromRequest(data interface{}, r *http.Request) (LoadContext, error)
 	NewRequest(urlString string, data interface{}, context SendContext) (*http.Request, error)
+}
+
+// ContextTranslator provides a set of translation methods between the
+// different versions of the CloudEvents spec, which allows programs to
+// interoperate with different versions of the CloudEvents spec by
+// converting EventContexts to their preferred version.
+type ContextTranslator interface {
+	// AsV01 provides a translation from whatever the "native" encoding of the
+	// CloudEvent was to the equivalent in v0.1 field names, moving fields to or
+	// from extensions as necessary.
+	AsV01() V01EventContext
+
+	// AsV02 provides a translation from whatever the "native" encoding of the
+	// CloudEvent was to the equivalent in v0.2 field names, moving fields to or
+	// from extensions as necessary.
+	AsV02() V02EventContext
+
+	// DataContentType returns the MIME content type for encoding data, which is
+	// needed by both encoding and decoding.
+	DataContentType() string
 }
 
 // SendContext provides an interface for extracting information from an
 // EventContext (the set of non-data event attributes of a CloudEvent).
 type SendContext interface {
+	ContextTranslator
+
 	StructuredSender
 	BinarySender
 }
 
 // LoadContext provides an interface for extracting information from an
 // EventContext (the set of non-data event attributes of a CloudEvent).
-//
-// LoadContext also provides a set of translation methods between the
-// versions of the CloudEvents spec, which allows programs to interoperate with
-// different versions of the CloudEvents spec at the same time.
 type LoadContext interface {
+	ContextTranslator
+
 	StructuredLoader
 	BinaryLoader
-
-	// AsV01 provides a translation from whatever the "native" encoding of the
-	// CloudEvent was to the equivalent in v0.1 field names, moving fields to or
-	// from extensions as necessary.
-	AsV01() V01EventContext
 }
 
 // ContextType is a unified interface for both sending and loading the
 // CloudEvent data across versions.
 type ContextType interface {
-	SendContext
-	LoadContext
+	ContextTranslator
+
+	StructuredSender
+	BinarySender
+
+	StructuredLoader
+	BinaryLoader
 }
 
 func anyError(errs ...error) error {
@@ -162,7 +182,7 @@ func marshalEventData(encoding string, data interface{}) ([]byte, error) {
 }
 
 // FromRequest parses a CloudEvent from any known encoding.
-func FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
+func FromRequest(data interface{}, r *http.Request) (LoadContext, error) {
 	switch r.Header.Get(HeaderContentType) {
 	case ContentTypeStructuredJSON:
 		return Structured.FromRequest(data, r)
@@ -187,6 +207,6 @@ type contextKeyType struct{}
 var contextKey = contextKeyType{}
 
 // FromContext loads an V01EventContext from a normal context.Context
-func FromContext(ctx context.Context) *V01EventContext {
-	return ctx.Value(contextKey).(*V01EventContext)
+func FromContext(ctx context.Context) LoadContext {
+	return ctx.Value(contextKey).(LoadContext)
 }

--- a/vendor/github.com/knative/pkg/cloudevents/event_v02.go
+++ b/vendor/github.com/knative/pkg/cloudevents/event_v02.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// V02CloudEventsVersion is the version of the CloudEvents spec targeted
+	// by this library.
+	V02CloudEventsVersion = "0.2"
+
+	// required attributes
+	fieldSpecVersion  = "specversion"
+	fieldID           = "id"
+	fieldType         = "type"
+	fieldSource       = "source"
+	fieldTime         = "time"
+	fieldSchemaURL    = "schemaurl"
+	fieldContentType  = "contenttype"
+	headerContentType = "Content-Type"
+)
+
+// V02EventContext represents the non-data attributes of a CloudEvents v0.2
+// event.
+type V02EventContext struct {
+	// The version of the CloudEvents specification used by the event.
+	SpecVersion string `json:"specversion"`
+	// The type of the occurrence which has happened.
+	Type string `json:"type"`
+	// A URI describing the event producer.
+	Source string `json:"source"`
+	// ID of the event; must be non-empty and unique within the scope of the producer.
+	ID string `json:"id"`
+	// Timestamp when the event happened.
+	Time time.Time `json:"time,omitempty"`
+	// A link to the schema that the `data` attribute adheres to.
+	SchemaURL string `json:"schemaurl,omitempty"`
+	// A MIME (RFC2046) string describing the media type of `data`.
+	// TODO: Should an empty string assume `application/json`, `application/octet-stream`, or auto-detect the content?
+	ContentType string `json:"contenttype,omitempty"`
+	// Additional extension metadata beyond the base spec.
+	Extensions map[string]interface{} `json:"-,omitempty"`
+}
+
+// AsV01 implements the ContextTranslator interface.
+func (ec V02EventContext) AsV01() V01EventContext {
+	ret := V01EventContext{
+		CloudEventsVersion: V01CloudEventsVersion,
+		EventID:            ec.ID,
+		EventTime:          ec.Time,
+		EventType:          ec.Type,
+		SchemaURL:          ec.SchemaURL,
+		ContentType:        ec.ContentType,
+		Source:             ec.Source,
+		Extensions:         make(map[string]interface{}),
+	}
+	for k, v := range ec.Extensions {
+		// eventTypeVersion was retired in v0.2
+		if strings.EqualFold(k, "eventTypeVersion") {
+			etv, ok := v.(string)
+			if ok {
+				ret.EventTypeVersion = etv
+			}
+			continue
+		}
+		ret.Extensions[k] = v
+	}
+	return ret
+}
+
+// AsV02 implements the ContextTranslator interface.
+func (ec V02EventContext) AsV02() V02EventContext {
+	return ec
+}
+
+// AsHeaders implements the BinarySender interface.
+func (ec V02EventContext) AsHeaders() (http.Header, error) {
+	h := http.Header{}
+	h.Set("CE-"+fieldSpecVersion, ec.SpecVersion)
+	h.Set("CE-"+fieldType, ec.Type)
+	h.Set("CE-"+fieldSource, ec.Source)
+	h.Set("CE-"+fieldID, ec.ID)
+	if ec.SpecVersion == "" {
+		h.Set("CE-"+fieldSpecVersion, V02CloudEventsVersion)
+	}
+	if !ec.Time.IsZero() {
+		h.Set("CE-"+fieldTime, ec.Time.Format(time.RFC3339Nano))
+	}
+	if ec.SchemaURL != "" {
+		h.Set("CE-"+fieldSchemaURL, ec.SchemaURL)
+	}
+	if ec.ContentType != "" {
+		h.Set(headerContentType, ec.ContentType)
+	}
+	for k, v := range ec.Extensions {
+		// Per spec, map-valued extensions are converted to a list of headers as:
+		// CE-attrib-key
+		if mapVal, ok := v.(map[string]interface{}); ok {
+			for subkey, subval := range mapVal {
+				encoded, err := json.Marshal(subval)
+				if err != nil {
+					return nil, err
+				}
+				h.Set("CE-"+k+"-"+subkey, string(encoded))
+			}
+			continue
+		}
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		h.Set("CE-"+k, string(encoded))
+	}
+
+	return h, nil
+}
+
+// FromHeaders implements the BinaryLoader interface.
+func (ec *V02EventContext) FromHeaders(in http.Header) error {
+	missingField := func(name string) error {
+		if in.Get("CE-"+name) == "" {
+			return fmt.Errorf("Missing field %q in %v: %q", "CE-"+name, in, in.Get("CE-"+name))
+		}
+		return nil
+	}
+	err := anyError(
+		missingField(fieldSpecVersion),
+		missingField(fieldID),
+		missingField(fieldType),
+		missingField(fieldSource),
+	)
+	if err != nil {
+		return err
+	}
+	data := V02EventContext{
+		ContentType: in.Get(headerContentType),
+		Extensions:  make(map[string]interface{}),
+	}
+	// Extensions and top-level fields are mixed under "CE-" headers.
+	// Extract them all here rather than trying to clear fields in headers.
+	for k, v := range in {
+		if strings.EqualFold(k[:len("CE-")], "CE-") {
+			key, value := strings.ToLower(string(k[len("CE-"):])), v[0]
+			switch key {
+			case fieldSpecVersion:
+				data.SpecVersion = value
+			case fieldType:
+				data.Type = value
+			case fieldSource:
+				data.Source = value
+			case fieldID:
+				data.ID = value
+			case fieldSchemaURL:
+				data.SchemaURL = value
+			case fieldTime:
+				if data.Time, err = time.Parse(time.RFC3339Nano, value); err != nil {
+					return err
+				}
+			default:
+				var tmp interface{}
+				if err = json.Unmarshal([]byte(value), &tmp); err != nil {
+					tmp = value
+				}
+				// Per spec, map-valued extensions are converted to a list of headers as:
+				// CE-attrib-key. This is where things get a bit crazy... see
+				// https://github.com/cloudevents/spec/issues/367 for additional notes.
+				if strings.Contains(key, "-") {
+					items := strings.SplitN(key, "-", 2)
+					key, subkey := items[0], items[1]
+					if _, ok := data.Extensions[key]; !ok {
+						data.Extensions[key] = make(map[string]interface{})
+					}
+					if submap, ok := data.Extensions[key].(map[string]interface{}); ok {
+						submap[subkey] = tmp
+					}
+				} else {
+					data.Extensions[key] = tmp
+				}
+			}
+		}
+	}
+	*ec = data
+	return nil
+}
+
+// AsJSON implementsn the StructuredSender interface.
+func (ec V02EventContext) AsJSON() (map[string]json.RawMessage, error) {
+	ret := make(map[string]json.RawMessage)
+	err := anyError(
+		encodeKey(ret, fieldSpecVersion, ec.SpecVersion),
+		encodeKey(ret, fieldType, ec.Type),
+		encodeKey(ret, fieldSource, ec.Source),
+		encodeKey(ret, fieldID, ec.ID),
+		encodeKey(ret, fieldTime, ec.Time),
+		encodeKey(ret, fieldSchemaURL, ec.SchemaURL),
+		encodeKey(ret, fieldContentType, ec.ContentType),
+	)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range ec.Extensions {
+		if err = encodeKey(ret, k, v); err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
+}
+
+// DataContentType implements the StructuredSender interface.
+func (ec V02EventContext) DataContentType() string {
+	return ec.ContentType
+}
+
+// FromJSON implements the StructuredLoader interface.
+func (ec *V02EventContext) FromJSON(in map[string]json.RawMessage) error {
+	data := V02EventContext{
+		SpecVersion: extractKey(in, fieldSpecVersion),
+		Type:        extractKey(in, fieldType),
+		Source:      extractKey(in, fieldSource),
+		ID:          extractKey(in, fieldID),
+		Extensions:  make(map[string]interface{}),
+	}
+	var err error
+	if timeStr := extractKey(in, fieldTime); timeStr != "" {
+		if data.Time, err = time.Parse(time.RFC3339Nano, timeStr); err != nil {
+			return err
+		}
+	}
+	extractKeyTo(in, fieldSchemaURL, &data.SchemaURL)
+	extractKeyTo(in, fieldContentType, &data.ContentType)
+	// Extract the remaining items from in by converting to JSON and then
+	// unpacking into Extensions. This avoids having to do funny type
+	// checking/testing in the loop over values.
+	extensionsJSON, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(extensionsJSON, &data.Extensions)
+	*ec = data
+	return err
+}

--- a/vendor/github.com/knative/pkg/cloudevents/handler.go
+++ b/vendor/github.com/knative/pkg/cloudevents/handler.go
@@ -48,7 +48,7 @@ type errAndHandler interface {
 
 const (
 	inParamUsage  = "Expected a function taking either no parameters, a context.Context, or (context.Context, any)"
-	outParamUsage = "Expected a function returning either nothing, an error, (any, error), or (any, EventContext, error)"
+	outParamUsage = "Expected a function returning either nothing, an error, (any, error), or (any, SendContext, error)"
 )
 
 var (
@@ -60,9 +60,9 @@ var (
 	// it leaves this stack frame. The workaround is to pass a pointer to an interface and then
 	// get the type of its reference.
 	// For example, see: https://play.golang.org/p/_dxLvdkvqvg
-	contextType      = reflect.TypeOf((*context.Context)(nil)).Elem()
-	errorType        = reflect.TypeOf((*error)(nil)).Elem()
-	eventContextType = reflect.TypeOf((*EventContext)(nil)).Elem()
+	contextType     = reflect.TypeOf((*context.Context)(nil)).Elem()
+	errorType       = reflect.TypeOf((*error)(nil)).Elem()
+	sendContextType = reflect.TypeOf((*SendContext)(nil)).Elem()
 )
 
 // Verifies that the inputs to a function have a valid signature; panics otherwise.
@@ -91,8 +91,8 @@ func validateOutParamSignature(fnType reflect.Type) error {
 	switch fnType.NumOut() {
 	case 3:
 		contextType := fnType.Out(1)
-		if !contextType.ConvertibleTo(eventContextType) {
-			return fmt.Errorf("%s; cannot convert return type 1 from %s to EventContext", outParamUsage, contextType)
+		if !contextType.ConvertibleTo(sendContextType) {
+			return fmt.Errorf("%s; cannot convert return type 1 from %s to SendContext", outParamUsage, contextType)
 		}
 		fallthrough
 	case 2:
@@ -145,7 +145,7 @@ func allocate(t reflect.Type) (asPtr interface{}, asValue reflect.Value) {
 	return
 }
 
-func unwrapReturnValues(res []reflect.Value) (interface{}, *EventContext, error) {
+func unwrapReturnValues(res []reflect.Value) (interface{}, SendContext, error) {
 	switch len(res) {
 	case 0:
 		return nil, nil, nil
@@ -163,8 +163,8 @@ func unwrapReturnValues(res []reflect.Value) (interface{}, *EventContext, error)
 		return nil, nil, res[1].Interface().(error)
 	case 3:
 		if res[2].IsNil() {
-			ec := res[1].Interface().(EventContext)
-			return res[0].Interface(), &ec, nil
+			ec := res[1].Interface().(SendContext)
+			return res[0].Interface(), ec, nil
 		}
 		return nil, nil, res[2].Interface().(error)
 	default:
@@ -192,7 +192,7 @@ func respondHTTP(outparams []reflect.Value, fn reflect.Value, w http.ResponseWri
 		if eventType == "" {
 			eventType = "dev.knative.pkg.cloudevents.unknown"
 		}
-		ec = &EventContext{
+		ec = &V01EventContext{
 			EventID:   uuid.New().String(),
 			EventType: eventType,
 			Source:    "unknown", // TODO: anything useful here, maybe incoming Host header?
@@ -207,7 +207,13 @@ func respondHTTP(outparams []reflect.Value, fn reflect.Value, w http.ResponseWri
 			w.Write([]byte(`Internal server error`))
 			return
 		}
-		headers := ec.AsHeaders()
+		headers, err := ec.AsHeaders()
+		if err != nil {
+			log.Printf("Failed to marshal event context %+v: %s", res, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Internal server error"))
+			return
+		}
 		for k, v := range headers {
 			w.Header()[k] = v
 		}


### PR DESCRIPTION
Fixes #190 
Related https://github.com/knative/pkg/issues/193

## Proposed Changes

  * Upgrades `knative/pkg`. I had to update a few files to match the pkg/cloudevents package upgrade, but this does not move event sources to v0.2 CloudEvents.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Removed the `Severity: Error` field from Conditions which was needlessly alarming human readers for conditions with Status=True.
```