### PR TITLE
Modify github source to add ability to specify api url for GHE

### DIFF
--- a/pkg/apis/sources/v1alpha1/githubsource_types.go
+++ b/pkg/apis/sources/v1alpha1/githubsource_types.go
@@ -69,6 +69,10 @@ type GitHubSourceSpec struct {
 	// name to use as the sink.
 	// +optional
 	Sink *corev1.ObjectReference `json:"sink,omitempty"`
+
+	// API URL if using github enterprise (default https://api.github.com)
+	// +optional
+	GitHubAPIURL string `json:"githubAPIURL,omitempty"`
 }
 
 // SecretValueFromSource represents the source of a secret value

--- a/pkg/reconciler/githubsource/githubsource.go
+++ b/pkg/reconciler/githubsource/githubsource.go
@@ -161,7 +161,7 @@ func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitH
 		r.addFinalizer(source)
 		if source.Status.WebhookIDKey == "" {
 			hookID, err := r.createWebhook(ctx, source,
-				receiveAdapterDomain, accessToken, secretToken)
+				receiveAdapterDomain, accessToken, secretToken, source.Spec.GitHubAPIURL)
 			if err != nil {
 				return err
 			}
@@ -188,7 +188,7 @@ func (r *reconciler) finalize(ctx context.Context, source *sourcesv1alpha1.GitHu
 		}
 
 		// Delete the webhook using the access token and stored webhook ID
-		err = r.deleteWebhook(ctx, source, accessToken, source.Status.WebhookIDKey)
+		err = r.deleteWebhook(ctx, source, accessToken, source.Status.WebhookIDKey, source.Spec.GitHubAPIURL)
 		if err != nil {
 			r.recorder.Eventf(source, corev1.EventTypeWarning, "FailedFinalize", "Could not delete webhook %q: %v", source.Status.WebhookIDKey, err)
 			return err
@@ -199,7 +199,7 @@ func (r *reconciler) finalize(ctx context.Context, source *sourcesv1alpha1.GitHu
 	return nil
 }
 
-func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, domain, accessToken, secretToken string) (string, error) {
+func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, domain, accessToken, secretToken, alternateGitHubAPIURL string) (string, error) {
 	logger := logging.FromContext(ctx)
 
 	logger.Info("creating GitHub webhook")
@@ -217,14 +217,14 @@ func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.
 		repo:        repo,
 		events:      source.Spec.EventTypes,
 	}
-	hookID, err := r.webhookClient.Create(ctx, hookOptions)
+	hookID, err := r.webhookClient.CreateWithGitHubBaseURL(ctx, hookOptions, alternateGitHubAPIURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to create webhook: %v", err)
 	}
 	return hookID, nil
 }
 
-func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, accessToken, hookID string) error {
+func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, accessToken, hookID, alternateGitHubAPIURL string) error {
 	logger := logging.FromContext(ctx)
 
 	logger.Info("deleting GitHub webhook")
@@ -240,7 +240,7 @@ func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.
 		repo:        repo,
 		events:      source.Spec.EventTypes,
 	}
-	err = r.webhookClient.Delete(ctx, hookOptions, hookID)
+	err = r.webhookClient.DeleteWithGitHubBaseURL(ctx, hookOptions, hookID, alternateGitHubAPIURL)
 	if err != nil {
 		return fmt.Errorf("failed to delete webhook: %v", err)
 	}


### PR DESCRIPTION
This change enables optionally specifying a githubAPIURL on the githubsource, saving the need for people to have to create a completly new eventsource to work with github enterprise.  

The new githubAPIURL field is optional and if not specified will default to the current behaviour, namely having the github public api base URL.

## Proposed Changes

  * Introduce optional githubAPIURL field on githubsource.  Users can then use a githubsource and specify the API URL of their GitHub Enterprise server

**Release Note**
```release-note
NONE
```

Note: Doc changes ready, PR not yet open as in docs repo (please advise when reviewing if I should open a PR and comment that it cannot be merged until after this change) - this is my first contribution so not exactly clear on process with multiple repos.