### PR TITLE
Modify github source to add ability to specify api url for GHE

### DIFF
--- a/pkg/apis/sources/v1alpha1/githubsource_types.go
+++ b/pkg/apis/sources/v1alpha1/githubsource_types.go
@@ -69,6 +69,10 @@ type GitHubSourceSpec struct {
 	// name to use as the sink.
 	// +optional
 	Sink *corev1.ObjectReference `json:"sink,omitempty"`
+
+	// API URL if using github enterprise (default https://api.github.com)
+	// +optional
+	GitHubAPIURL string `json:"githubAPIURL,omitempty"`
 }
 
 // SecretValueFromSource represents the source of a secret value

--- a/pkg/reconciler/githubsource/githubsource.go
+++ b/pkg/reconciler/githubsource/githubsource.go
@@ -200,6 +200,16 @@ func (r *reconciler) finalize(ctx context.Context, source *sourcesv1alpha1.GitHu
 }
 
 func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, domain, accessToken, secretToken, alternateGitHubAPIURL string) (string, error) {
+	// TODO: Modify function args to shorten method signature ... something like
+	// func (r *reconciler) createWebhook(ctx context.Context, args createWebhookArgs) (string, error) {...}
+	// where createWebhookArgs is a struct like....
+	// type createWebhookArgs struct {
+	//  source *sourcesv1alpha1.GitHubSource
+	//  domain string
+	//  accessToken string
+	//  secretToken string
+	//  alternateGitHubAPIURL string
+	// }
 	logger := logging.FromContext(ctx)
 
 	logger.Info("creating GitHub webhook")
@@ -217,7 +227,7 @@ func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.
 		repo:        repo,
 		events:      source.Spec.EventTypes,
 	}
-	hookID, err := r.webhookClient.CreateWithGitHubBaseURL(ctx, hookOptions, alternateGitHubAPIURL)
+	hookID, err := r.webhookClient.Create(ctx, hookOptions, alternateGitHubAPIURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to create webhook: %v", err)
 	}
@@ -225,6 +235,16 @@ func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.
 }
 
 func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, accessToken, hookID, alternateGitHubAPIURL string) error {
+	// TODO: Modify function args to shorten method signature ... something like
+	// func (r *reconciler) createWebhook(ctx context.Context, args createWebhookArgs) (string, error) {...}
+	// where createWebhookArgs is a struct like....
+	// type createWebhookArgs struct {
+	//  source *sourcesv1alpha1.GitHubSource
+	//  domain string
+	//  accessToken string
+	//  secretToken string
+	//  alternateGitHubAPIURL string
+	// }
 	logger := logging.FromContext(ctx)
 
 	logger.Info("deleting GitHub webhook")
@@ -240,7 +260,7 @@ func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.
 		repo:        repo,
 		events:      source.Spec.EventTypes,
 	}
-	err = r.webhookClient.DeleteWithGitHubBaseURL(ctx, hookOptions, hookID, alternateGitHubAPIURL)
+	err = r.webhookClient.Delete(ctx, hookOptions, hookID, alternateGitHubAPIURL)
 	if err != nil {
 		return fmt.Errorf("failed to delete webhook: %v", err)
 	}

--- a/pkg/reconciler/githubsource/githubsource.go
+++ b/pkg/reconciler/githubsource/githubsource.go
@@ -201,14 +201,15 @@ func (r *reconciler) finalize(ctx context.Context, source *sourcesv1alpha1.GitHu
 
 func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, domain, accessToken, secretToken, alternateGitHubAPIURL string) (string, error) {
 	// TODO: Modify function args to shorten method signature ... something like
-	// func (r *reconciler) createWebhook(ctx context.Context, args createWebhookArgs) (string, error) {...}
-	// where createWebhookArgs is a struct like....
-	// type createWebhookArgs struct {
+	// func (r *reconciler) createWebhook(ctx context.Context, args webhookArgs) (string, error) {...}
+	// where webhookArgs is a struct like....
+	// type webhookArgs struct {
 	//  source *sourcesv1alpha1.GitHubSource
 	//  domain string
 	//  accessToken string
 	//  secretToken string
 	//  alternateGitHubAPIURL string
+	//  hookID string
 	// }
 	logger := logging.FromContext(ctx)
 
@@ -236,14 +237,15 @@ func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.
 
 func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, accessToken, hookID, alternateGitHubAPIURL string) error {
 	// TODO: Modify function args to shorten method signature ... something like
-	// func (r *reconciler) createWebhook(ctx context.Context, args createWebhookArgs) (string, error) {...}
-	// where createWebhookArgs is a struct like....
-	// type createWebhookArgs struct {
+	// func (r *reconciler) deleteWebhook(ctx context.Context, args webhookArgs) (string, error) {...}
+	// where webhookArgs is a struct like....
+	// type webhookArgs struct {
 	//  source *sourcesv1alpha1.GitHubSource
 	//  domain string
 	//  accessToken string
 	//  secretToken string
 	//  alternateGitHubAPIURL string
+	//  hookID string
 	// }
 	logger := logging.FromContext(ctx)
 

--- a/pkg/reconciler/githubsource/githubsource.go
+++ b/pkg/reconciler/githubsource/githubsource.go
@@ -161,7 +161,7 @@ func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitH
 		r.addFinalizer(source)
 		if source.Status.WebhookIDKey == "" {
 			hookID, err := r.createWebhook(ctx, source,
-				receiveAdapterDomain, accessToken, secretToken)
+				receiveAdapterDomain, accessToken, secretToken, source.Spec.GitHubAPIURL)
 			if err != nil {
 				return err
 			}
@@ -188,7 +188,7 @@ func (r *reconciler) finalize(ctx context.Context, source *sourcesv1alpha1.GitHu
 		}
 
 		// Delete the webhook using the access token and stored webhook ID
-		err = r.deleteWebhook(ctx, source, accessToken, source.Status.WebhookIDKey)
+		err = r.deleteWebhook(ctx, source, accessToken, source.Status.WebhookIDKey, source.Spec.GitHubAPIURL)
 		if err != nil {
 			r.recorder.Eventf(source, corev1.EventTypeWarning, "FailedFinalize", "Could not delete webhook %q: %v", source.Status.WebhookIDKey, err)
 			return err
@@ -199,7 +199,7 @@ func (r *reconciler) finalize(ctx context.Context, source *sourcesv1alpha1.GitHu
 	return nil
 }
 
-func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, domain, accessToken, secretToken string) (string, error) {
+func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, domain, accessToken, secretToken, alternateGitHubAPIURL string) (string, error) {
 	logger := logging.FromContext(ctx)
 
 	logger.Info("creating GitHub webhook")
@@ -217,14 +217,14 @@ func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.
 		repo:        repo,
 		events:      source.Spec.EventTypes,
 	}
-	hookID, err := r.webhookClient.Create(ctx, hookOptions)
+	hookID, err := r.webhookClient.CreateWithGitHubBaseURL(ctx, hookOptions, alternateGitHubAPIURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to create webhook: %v", err)
 	}
 	return hookID, nil
 }
 
-func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, accessToken, hookID string) error {
+func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.GitHubSource, accessToken, hookID, alternateGitHubAPIURL string) error {
 	logger := logging.FromContext(ctx)
 
 	logger.Info("deleting GitHub webhook")
@@ -240,7 +240,7 @@ func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.
 		repo:        repo,
 		events:      source.Spec.EventTypes,
 	}
-	err = r.webhookClient.Delete(ctx, hookOptions, hookID)
+	err = r.webhookClient.DeleteWithGitHubBaseURL(ctx, hookOptions, hookID, alternateGitHubAPIURL)
 	if err != nil {
 		return fmt.Errorf("failed to delete webhook: %v", err)
 	}

--- a/pkg/reconciler/githubsource/githubsource_test.go
+++ b/pkg/reconciler/githubsource/githubsource_test.go
@@ -768,11 +768,7 @@ type mockWebhookClient struct {
 	data webhookCreatorData
 }
 
-func (client mockWebhookClient) Create(ctx context.Context, options *webhookOptions) (string, error) {
-	return client.CreateWithGitHubBaseURL(ctx, options, "")
-}
-
-func (client mockWebhookClient) CreateWithGitHubBaseURL(ctx context.Context, options *webhookOptions, altGHURL string) (string, error) {
+func (client mockWebhookClient) Create(ctx context.Context, options *webhookOptions, altGHURL string) (string, error) {
 	data := client.data
 	if data.clientCreateErr != nil {
 		return "", data.clientCreateErr
@@ -788,11 +784,7 @@ func (client mockWebhookClient) CreateWithGitHubBaseURL(ctx context.Context, opt
 	return data.hookID, nil
 }
 
-func (client mockWebhookClient) Delete(ctx context.Context, options *webhookOptions, hookID string) error {
-	return client.DeleteWithGitHubBaseURL(ctx, options, hookID, "")
-}
-
-func (client mockWebhookClient) DeleteWithGitHubBaseURL(ctx context.Context, options *webhookOptions, hookID, altGHURL string) error {
+func (client mockWebhookClient) Delete(ctx context.Context, options *webhookOptions, hookID, altGHURL string) error {
 	data := client.data
 	if data.expectedOwner != options.owner {
 		return fmt.Errorf(`expected webhook owner of "%s", got "%s"`,

--- a/pkg/reconciler/githubsource/webhook_client.go
+++ b/pkg/reconciler/githubsource/webhook_client.go
@@ -51,7 +51,7 @@ func (client gitHubWebhookClient) Create(ctx context.Context, options *webhookOp
 		//This is to support GitHub Enterprise, this might be something like https://github.company.com/api/v3/
 		baseURL, err := url.Parse(alternateGitHubAPIURL)
 		if err != nil {
-			logger.Infof("failed to create webhook - error occured parsing githubAPIURL %s, error was %v", alternateGitHubAPIURL, err)
+			logger.Infof("Failed to create webhook because an error occured parsing githubAPIURL %q, error was: %v", alternateGitHubAPIURL, err)
 			return "", fmt.Errorf("error occured parsing githubAPIURL: %v", err)
 		}
 		ghClient.BaseURL = baseURL
@@ -86,12 +86,11 @@ func (client gitHubWebhookClient) Delete(ctx context.Context, options *webhookOp
 
 	ghClient := client.createGitHubClient(ctx, options)
 	if alternateGitHubAPIURL != "" {
-		baseURL, err := url.Parse(alternateGitHubAPIURL)
+		ghClient.BaseURL, err = url.Parse(alternateGitHubAPIURL)
 		if err != nil {
-			logger.Infof("failed to delete webhook - error occured parsing githubAPIURL %s, error was %v", alternateGitHubAPIURL, err)
+			logger.Infof("Failed to delete webhook because an error occured parsing githubAPIURL %q, error was: %v", alternateGitHubAPIURL, err)
 			return fmt.Errorf("error occured parsing githubAPIURL: %v", err)
 		}
-		ghClient.BaseURL = baseURL
 	}
 
 	hook := client.hookConfig(ctx, options)

--- a/pkg/reconciler/githubsource/webhook_client.go
+++ b/pkg/reconciler/githubsource/webhook_client.go
@@ -51,8 +51,8 @@ func (client gitHubWebhookClient) Create(ctx context.Context, options *webhookOp
 		//This is to support GitHub Enterprise, this might be something like https://github.company.com/api/v3/
 		baseURL, err := url.Parse(alternateGitHubAPIURL)
 		if err != nil {
-			logger.Infof("Failed to create webhook - Error occured parsing githubAPIURL %s, error was %v", alternateGitHubAPIURL, err)
-			return "", fmt.Errorf("Error occured parsing githubAPIURL: %v", err)
+			logger.Infof("failed to create webhook - error occured parsing githubAPIURL %s, error was %v", alternateGitHubAPIURL, err)
+			return "", fmt.Errorf("error occured parsing githubAPIURL: %v", err)
 		}
 		ghClient.BaseURL = baseURL
 	}
@@ -88,8 +88,8 @@ func (client gitHubWebhookClient) Delete(ctx context.Context, options *webhookOp
 	if alternateGitHubAPIURL != "" {
 		baseURL, err := url.Parse(alternateGitHubAPIURL)
 		if err != nil {
-			logger.Infof("Failed to delete webhook - Error occured parsing githubAPIURL %s, error was %v", alternateGitHubAPIURL, err)
-			return fmt.Errorf("Error occured parsing githubAPIURL: %v", err)
+			logger.Infof("failed to delete webhook - error occured parsing githubAPIURL %s, error was %v", alternateGitHubAPIURL, err)
+			return fmt.Errorf("error occured parsing githubAPIURL: %v", err)
 		}
 		ghClient.BaseURL = baseURL
 	}


### PR DESCRIPTION
This change enables optionally specifying a githubAPIURL on the githubsource, saving the need for people to have to create a completly new eventsource to work with github enterprise.  

The new githubAPIURL field is optional and if not specified will default to the current behaviour, namely having the github public api base URL.

## Proposed Changes

  * Introduce optional githubAPIURL field on githubsource.  Users can then use a githubsource and specify the API URL of their GitHub Enterprise server

**Release Note**
```release-note
NONE
```

Note: Doc changes ready, PR not yet open as in docs repo (please advise when reviewing if I should open a PR and comment that it cannot be merged until after this change) - this is my first contribution so not exactly clear on process with multiple repos.