### PR TITLE
Update cloudevent sdk to include auto-generated uuid options.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -63,7 +63,7 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:480b0af975a84b4de23acb40a4bf206bb0586862f466f8eba1ba468374b311dd"
+  digest = "1:d9cc48e9d4caa22c2af5b18f404d3e4a34b05e6723b002c0c18a39762a14777d"
   name = "github.com/cloudevents/sdk-go"
   packages = [
     "pkg/cloudevents",
@@ -78,7 +78,7 @@
     "pkg/cloudevents/types",
   ]
   pruneopts = "NUT"
-  revision = "0ad07eed0bed90a02b52767cee062dcaa5573179"
+  revision = "d50361a5655081514f406b4e672d72e9886c17ad"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -93,8 +93,8 @@ required = [
   name = "github.com/gorilla/websocket"
   version = "1.4.0"
 
-# Use CloudEvents, master as of Feb 25, 2019
+# Use CloudEvents, master as of Feb 28, 2019 🎂
 # Will use releases as soon as they get releases going.
 [[override]]
   name = "github.com/cloudevents/sdk-go"
-  revision = "0ad07eed0bed90a02b52767cee062dcaa5573179"
+  revision = "d50361a5655081514f406b4e672d72e9886c17ad"

--- a/cmd/heartbeats/main.go
+++ b/cmd/heartbeats/main.go
@@ -27,9 +27,7 @@ import (
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -74,7 +72,12 @@ func main() {
 		sink = env.Sink
 	}
 
-	c, err := client.NewHTTPClient(client.WithTarget(sink), client.WithHTTPEncoding(http.BinaryV02))
+	c, err := client.NewHTTPClient(
+		client.WithTarget(sink),
+		client.WithHTTPBinaryEncoding(),
+		client.WithTimeNow(),
+		client.WithUUIDs(),
+	)
 	if err != nil {
 		log.Fatalf("failed to create client: %s", err.Error())
 	}
@@ -103,7 +106,6 @@ func main() {
 
 		event := cloudevents.Event{
 			Context: cloudevents.EventContextV02{
-				ID:     uuid.New().String(),
 				Type:   "dev.knative.eventing.samples.heartbeat",
 				Source: *source,
 			},

--- a/cmd/heartbeats_receiver/main.go
+++ b/cmd/heartbeats_receiver/main.go
@@ -31,13 +31,13 @@ type Heartbeat struct {
 }
 
 func receive(event cloudevents.Event) {
-	ec := event.Context.AsV01()
+	ec := event.Context.AsV02()
 	hb := &Heartbeat{}
 	if err := event.DataAs(hb); err != nil {
 		fmt.Printf("got data error: %s\n", err.Error())
 	}
 	log.Printf("CloudEvent:\n%s", event)
-	log.Printf("[%s] %s %s: ", ec.EventTime, ec.ContentType, ec.Source.String())
+	log.Printf("[%s] %s %s: ", ec.Time, ec.ContentType, ec.Source.String())
 	log.Printf("\t%d, %q", hb.Sequence, hb.Label)
 }
 

--- a/cmd/heartbeats_receiver/main.go
+++ b/cmd/heartbeats_receiver/main.go
@@ -37,7 +37,7 @@ func receive(event cloudevents.Event) {
 		fmt.Printf("got data error: %s\n", err.Error())
 	}
 	log.Printf("CloudEvent:\n%s", event)
-	log.Printf("[%s] %s %s: ", ec.Time, ec.ContentType, ec.Source.String())
+	log.Printf("[%s] %s %s: ", ec.Time, event.DataContentType(), ec.Source.String())
 	log.Printf("\t%d, %q", hb.Sequence, hb.Label)
 }
 

--- a/pkg/adapter/kubernetesevents/adapter.go
+++ b/pkg/adapter/kubernetesevents/adapter.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
@@ -101,7 +100,7 @@ func (a *Adapter) addEvent(new interface{}) {
 
 	if a.ceClient == nil {
 		var err error
-		a.ceClient, err = client.NewHTTPClient(client.WithTarget(a.SinkURI), client.WithHTTPEncoding(http.BinaryV02))
+		a.ceClient, err = client.NewHTTPClient(client.WithTarget(a.SinkURI), client.WithHTTPBinaryEncoding())
 		if err != nil {
 			logger.Errorf("failed to create cloudevent client: %s", err.Error())
 			return

--- a/pkg/adapter/kubernetesevents/cloudevent_test.go
+++ b/pkg/adapter/kubernetesevents/cloudevent_test.go
@@ -55,12 +55,11 @@ func TestCloudEventFrom(t *testing.T) {
 
 	want := cloudevents.Event{
 		Context: cloudevents.EventContextV02{
-			SpecVersion: "0.2",
-			Type:        eventType,
-			ID:          string(uid),
-			Source:      *cetypes.ParseURLRef(refLink),
-			Time:        &cetypes.Timestamp{Time: now},
-		},
+			Type:   eventType,
+			ID:     string(uid),
+			Source: *cetypes.ParseURLRef(refLink),
+			Time:   &cetypes.Timestamp{Time: now},
+		}.AsV02(),
 		Data: event,
 	}
 

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/client.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/client.go
@@ -21,12 +21,26 @@ type Client interface {
 type ceClient struct {
 	transport transport.Sender
 	receiver  Receiver
+
+	eventDefaulterFns []EventDefaulter
 }
 
 func (c *ceClient) Send(ctx context.Context, event cloudevents.Event) error {
+	// Confirm we have a transport set.
 	if c.transport == nil {
 		return fmt.Errorf("client not ready, transport not initalized")
 	}
+	// Apply the defaulter chain to the incoming event.
+	if len(c.eventDefaulterFns) > 0 {
+		for _, fn := range c.eventDefaulterFns {
+			event = fn(event)
+		}
+	}
+	// Validate the event conforms to the CloudEvents Spec.
+	if err := event.Validate(); err != nil {
+		return err
+	}
+	// Send the event over the transport.
 	return c.transport.Send(ctx, event)
 }
 

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/defaulters.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/defaulters.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"github.com/google/uuid"
+	"time"
+)
+
+type EventDefaulter func(event cloudevents.Event) cloudevents.Event
+
+func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
+	if event.Context != nil {
+		switch event.Context.GetSpecVersion() {
+		case cloudevents.CloudEventsVersionV01:
+			ec := event.Context.AsV01()
+			if ec.EventID == "" {
+				ec.EventID = uuid.New().String()
+				event.Context = ec
+			}
+		case cloudevents.CloudEventsVersionV02:
+			ec := event.Context.AsV02()
+			if ec.ID == "" {
+				ec.ID = uuid.New().String()
+				event.Context = ec
+			}
+		case cloudevents.CloudEventsVersionV03:
+			ec := event.Context.AsV03()
+			if ec.ID == "" {
+				ec.ID = uuid.New().String()
+				event.Context = ec
+			}
+		}
+	}
+	return event
+}
+
+func DefaultTimeToNowIfNotSet(event cloudevents.Event) cloudevents.Event {
+	if event.Context != nil {
+		switch event.Context.GetSpecVersion() {
+		case cloudevents.CloudEventsVersionV01:
+			ec := event.Context.AsV01()
+			if ec.EventTime == nil || ec.EventTime.IsZero() {
+				ec.EventTime = &types.Timestamp{Time: time.Now()}
+				event.Context = ec
+			}
+		case cloudevents.CloudEventsVersionV02:
+			ec := event.Context.AsV02()
+			if ec.Time == nil || ec.Time.IsZero() {
+				ec.Time = &types.Timestamp{Time: time.Now()}
+				event.Context = ec
+			}
+		case cloudevents.CloudEventsVersionV03:
+			ec := event.Context.AsV03()
+			if ec.Time == nil || ec.Time.IsZero() {
+				ec.Time = &types.Timestamp{Time: time.Now()}
+				event.Context = ec
+			}
+		}
+	}
+	return event
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/options.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/options.go
@@ -31,9 +31,8 @@ func WithTarget(targetUrl string) Option {
 				}
 				t.Req.URL = target
 				return nil
-			} else {
-				return fmt.Errorf("target option was empty string")
 			}
+			return fmt.Errorf("target option was empty string")
 		}
 		return fmt.Errorf("invalid target client option received for transport type")
 	}
@@ -50,9 +49,8 @@ func WithHTTPMethod(method string) Option {
 				}
 				t.Req.Method = method
 				return nil
-			} else {
-				return fmt.Errorf("method option was empty string")
 			}
+			return fmt.Errorf("method option was empty string")
 		}
 		return fmt.Errorf("invalid HTTP method client option received for transport type")
 	}
@@ -66,6 +64,47 @@ func WithHTTPEncoding(encoding http.Encoding) Option {
 			return nil
 		}
 		return fmt.Errorf("invalid HTTP encoding client option received for transport type")
+	}
+}
+
+// WithHTTPDefaultEncodingSelector sets the encoding selection strategy for
+// default encoding selections based on Event.
+func WithHTTPDefaultEncodingSelector(fn http.EncodingSelector) Option {
+	return func(c *ceClient) error {
+		if t, ok := c.transport.(*http.Transport); ok {
+			if fn != nil {
+				t.DefaultEncodingSelectionFn = fn
+				return nil
+			}
+			return fmt.Errorf("fn for DefaultEncodingSelector was nil")
+		}
+		return fmt.Errorf("invalid HTTP default encoding selector client option received for transport type")
+	}
+}
+
+// WithHTTPBinaryEncodingSelector sets the encoding selection strategy for
+// default encoding selections based on Event, the encoded event will be the
+// given version in Binary form.
+func WithHTTPBinaryEncoding() Option {
+	return func(c *ceClient) error {
+		if t, ok := c.transport.(*http.Transport); ok {
+			t.DefaultEncodingSelectionFn = http.DefaultBinaryEncodingSelectionStrategy
+			return nil
+		}
+		return fmt.Errorf("invalid HTTP binary encoding client option received for transport type")
+	}
+}
+
+// WithHTTPStructuredEncodingSelector sets the encoding selection strategy for
+// default encoding selections based on Event, the encoded event will be the
+//// given version in Structured form.
+func WithHTTPStructuredEncoding() Option {
+	return func(c *ceClient) error {
+		if t, ok := c.transport.(*http.Transport); ok {
+			t.DefaultEncodingSelectionFn = http.DefaultStructuredEncodingSelectionStrategy
+			return nil
+		}
+		return fmt.Errorf("invalid HTTP structured encoding client option received for transport type")
 	}
 }
 
@@ -105,5 +144,34 @@ func WithNATSEncoding(encoding nats.Encoding) Option {
 			return nil
 		}
 		return fmt.Errorf("invalid NATS encoding client option received for transport type")
+	}
+}
+
+// WithEventDefaulter adds an event defaulter to the end of the defaulter chain.
+func WithEventDefaulter(fn EventDefaulter) Option {
+	return func(c *ceClient) error {
+		if fn == nil {
+			return fmt.Errorf("client option was given an nil event defaulter")
+		}
+		c.eventDefaulterFns = append(c.eventDefaulterFns, fn)
+		return nil
+	}
+}
+
+// WithUUIDs adds DefaultIDToUUIDIfNotSet event defaulter to the end of the
+// defaulter chain.
+func WithUUIDs() Option {
+	return func(c *ceClient) error {
+		c.eventDefaulterFns = append(c.eventDefaulterFns, DefaultIDToUUIDIfNotSet)
+		return nil
+	}
+}
+
+// WithTimeNow adds DefaultTimeToNowIfNotSet event defaulter to the end of the
+// defaulter chain.
+func WithTimeNow() Option {
+	return func(c *ceClient) error {
+		c.eventDefaulterFns = append(c.eventDefaulterFns, DefaultTimeToNowIfNotSet)
+		return nil
 	}
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/codec/jsoncodec.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/codec/jsoncodec.go
@@ -10,24 +10,24 @@ import (
 
 func JsonEncodeV01(e cloudevents.Event) ([]byte, error) {
 	ctx := e.Context.AsV01()
-	if ctx.ContentType == "" {
-		ctx.ContentType = "application/json"
+	if ctx.ContentType == nil {
+		ctx.ContentType = cloudevents.StringOfApplicationJSON()
 	}
 	return jsonEncode(ctx, e.Data)
 }
 
 func JsonEncodeV02(e cloudevents.Event) ([]byte, error) {
 	ctx := e.Context.AsV02()
-	if ctx.ContentType == "" {
-		ctx.ContentType = "application/json"
+	if ctx.ContentType == nil {
+		ctx.ContentType = cloudevents.StringOfApplicationJSON()
 	}
 	return jsonEncode(ctx, e.Data)
 }
 
 func JsonEncodeV03(e cloudevents.Event) ([]byte, error) {
 	ctx := e.Context.AsV03()
-	if ctx.DataContentType == "" {
-		ctx.DataContentType = "application/json"
+	if ctx.DataContentType == nil {
+		ctx.DataContentType = cloudevents.StringOfApplicationJSON()
 	}
 	return jsonEncode(ctx, e.Data)
 }
@@ -45,13 +45,13 @@ func jsonEncode(ctx cloudevents.EventContext, data interface{}) ([]byte, error) 
 		return nil, err
 	}
 
-	dataContentType := ctx.GetDataContentType()
-	datab, err := marshalEventData(dataContentType, data)
+	mediaType := ctx.GetDataMediaType()
+	datab, err := marshalEventData(mediaType, data)
 	if err != nil {
 		return nil, err
 	}
 	if data != nil {
-		if dataContentType == "" || dataContentType == "application/json" {
+		if mediaType == "" || mediaType == cloudevents.ApplicationJSON {
 			b["data"] = datab
 		} else if datab[0] != byte('"') {
 			b["data"] = []byte(strconv.QuoteToASCII(string(datab)))

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/content_type.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/content_type.go
@@ -1,0 +1,34 @@
+package cloudevents
+
+const (
+	ApplicationJSON                 = "application/json"
+	ApplicationXML                  = "application/xml"
+	ApplicationCloudEventsJSON      = "application/cloudevents+json"
+	ApplicationCloudEventsBatchJSON = "application/cloudevents-batch+json"
+)
+
+// StringOfApplicationJSON returns a string pointer to "application/json"
+func StringOfApplicationJSON() *string {
+	a := ApplicationJSON
+	return &a
+}
+
+// StringOfApplicationXML returns a string pointer to "application/xml"
+func StringOfApplicationXML() *string {
+	a := ApplicationXML
+	return &a
+}
+
+// StringOfApplicationCloudEventsJSON  returns a string pointer to
+// "application/cloudevents+json"
+func StringOfApplicationCloudEventsJSON() *string {
+	a := ApplicationCloudEventsJSON
+	return &a
+}
+
+// StringOfApplicationCloudEventsBatchJSON returns a string pointer to
+// "application/cloudevents-batch+json"
+func StringOfApplicationCloudEventsBatchJSON() *string {
+	a := ApplicationCloudEventsBatchJSON
+	return &a
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event.go
@@ -1,6 +1,7 @@
 package cloudevents
 
 import (
+	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
 	"strings"
 )
@@ -12,7 +13,7 @@ type Event struct {
 }
 
 func (e Event) DataAs(data interface{}) error {
-	return datacodec.Decode(e.Context.GetDataContentType(), e.Data, data)
+	return datacodec.Decode(e.Context.GetDataMediaType(), e.Data, data)
 }
 
 func (e Event) SpecVersion() string {
@@ -25,6 +26,20 @@ func (e Event) Type() string {
 
 func (e Event) DataContentType() string {
 	return e.Context.GetDataContentType()
+}
+
+func (e Event) Validate() error {
+	if e.Context == nil {
+		return fmt.Errorf("every event conforming to the CloudEvents specification MUST include a context")
+	}
+
+	if err := e.Context.Validate(); err != nil {
+		return err
+	}
+
+	// TODO: validate data.
+
+	return nil
 }
 
 func (e Event) String() string {

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext.go
@@ -16,9 +16,12 @@ type EventContext interface {
 	// from extensions as necessary.
 	AsV03() EventContextV03
 
-	// GetDataContentType returns the MIME content type for encoding data, which is
-	// needed by both encoding and decoding.
+	// GetDataContentType returns content type on the context.
 	GetDataContentType() string
+
+	// GetDataMediaType returns the MIME media type for encoded data, which is
+	// needed by both encoding and decoding.
+	GetDataMediaType() string
 
 	// GetSpecVersion returns the native CloudEvents Spec version of the event
 	// context.
@@ -26,4 +29,6 @@ type EventContext interface {
 
 	// GetType returns the CloudEvents type from the context.
 	GetType() string
+
+	Validate() error
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v01.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v01.go
@@ -1,7 +1,10 @@
 package cloudevents
 
 import (
+	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"log"
+	"mime"
 	"strings"
 )
 
@@ -23,12 +26,12 @@ type EventContextV01 struct {
 	// Type of occurrence which has happened.
 	EventType string `json:"eventType"`
 	// The version of the `eventType`; this is producer-specific.
-	EventTypeVersion string `json:"eventTypeVersion,omitempty"`
+	EventTypeVersion *string `json:"eventTypeVersion,omitempty"`
 	// A link to the schema that the `data` attribute adheres to.
 	SchemaURL *types.URLRef `json:"schemaURL,omitempty"`
 	// A MIME (RFC 2046) string describing the media type of `data`.
 	// TODO: Should an empty string assume `application/json`, or auto-detect the content?
-	ContentType string `json:"contentType,omitempty"`
+	ContentType *string `json:"contentType,omitempty"`
 	// A URI describing the event producer.
 	Source types.URLRef `json:"source"`
 	// Additional metadata without a well-defined structure.
@@ -45,15 +48,22 @@ func (ec EventContextV01) GetSpecVersion() string {
 }
 
 func (ec EventContextV01) GetDataContentType() string {
-	// TODO: there are cases where there is char encoding info on the content type.
-	// Fix this for these cases as we find them.
-	if strings.HasSuffix(ec.ContentType, "json") {
-		return "application/json"
+	if ec.ContentType != nil {
+		return *ec.ContentType
 	}
-	if strings.HasSuffix(ec.ContentType, "xml") {
-		return "application/xml"
+	return ""
+}
+
+func (ec EventContextV01) GetDataMediaType() string {
+	if ec.ContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
+		if err != nil {
+			log.Printf("failed to parse media type from ContentType: %s", err)
+			return ""
+		}
+		return mediaType
 	}
-	return ec.ContentType
+	return ""
 }
 
 func (ec EventContextV01) GetType() string {
@@ -76,9 +86,10 @@ func (ec EventContextV01) AsV02() EventContextV02 {
 		ContentType: ec.ContentType,
 		Extensions:  make(map[string]interface{}),
 	}
+
 	// eventTypeVersion was retired in v0.2, so put it in an extension.
-	if ec.EventTypeVersion != "" {
-		ret.Extensions["eventTypeVersion"] = ec.EventTypeVersion
+	if ec.EventTypeVersion != nil {
+		ret.Extensions["eventTypeVersion"] = *ec.EventTypeVersion
 	}
 	if ec.Extensions != nil {
 		for k, v := range ec.Extensions {
@@ -94,4 +105,114 @@ func (ec EventContextV01) AsV02() EventContextV02 {
 func (ec EventContextV01) AsV03() EventContextV03 {
 	ecv2 := ec.AsV02()
 	return ecv2.AsV03()
+}
+
+// Validate returns errors based on requirements from the CloudEvents spec.
+// For more details, see https://github.com/cloudevents/spec/blob/v0.1/spec.md
+func (ec EventContextV01) Validate() error {
+	errors := []string(nil)
+
+	// eventType
+	// Type: String
+	// Constraints:
+	// 	REQUIRED
+	// 	MUST be a non-empty string
+	// 	SHOULD be prefixed with a reverse-DNS name. The prefixed domain dictates the organization which defines the semantics of this event type.
+	eventType := strings.TrimSpace(ec.EventType)
+	if eventType == "" {
+		errors = append(errors, "eventType: MUST be a non-empty string")
+	}
+
+	// eventTypeVersion
+	// Type: String
+	// Constraints:
+	// 	OPTIONAL
+	// 	If present, MUST be a non-empty string
+	if ec.EventTypeVersion != nil {
+		eventTypeVersion := strings.TrimSpace(*ec.EventTypeVersion)
+		if eventTypeVersion == "" {
+			errors = append(errors, "eventTypeVersion: if present, MUST be a non-empty string")
+		}
+	}
+
+	// cloudEventsVersion
+	// Type: String
+	// Constraints:
+	// 	REQUIRED
+	// 	MUST be a non-empty string
+	cloudEventsVersion := strings.TrimSpace(ec.CloudEventsVersion)
+	if cloudEventsVersion == "" {
+		errors = append(errors, "cloudEventsVersion: MUST be a non-empty string")
+	}
+
+	// source
+	// Type: URI
+	// Constraints:
+	// 	REQUIRED
+	source := strings.TrimSpace(ec.Source.String())
+	if source == "" {
+		errors = append(errors, "source: REQUIRED")
+	}
+
+	// eventID
+	// Type: String
+	// Constraints:
+	// 	REQUIRED
+	// 	MUST be a non-empty string
+	// 	MUST be unique within the scope of the producer
+	eventID := strings.TrimSpace(ec.EventID)
+	if eventID == "" {
+		errors = append(errors, "eventID: MUST be a non-empty string")
+
+		// no way to test "MUST be unique within the scope of the producer"
+	}
+
+	// eventTime
+	// Type: Timestamp
+	// Constraints:
+	// 	OPTIONAL
+	//	If present, MUST adhere to the format specified in RFC 3339
+	// --> no need to test this, no way to set the eventTime without it being valid.
+
+	// schemaURL
+	// Type: URI
+	// Constraints:
+	// 	OPTIONAL
+	// 	If present, MUST adhere to the format specified in RFC 3986
+	if ec.SchemaURL != nil {
+		schemaURL := strings.TrimSpace(ec.SchemaURL.String())
+		// empty string is not RFC 3986 compatible.
+		if schemaURL == "" {
+			errors = append(errors, "schemaURL: if present, MUST adhere to the format specified in RFC 3986")
+		}
+	}
+
+	// contentType
+	// Type: String per RFC 2046
+	// Constraints:
+	// 	OPTIONAL
+	// 	If present, MUST adhere to the format specified in RFC 2046
+	if ec.ContentType != nil {
+		contentType := strings.TrimSpace(*ec.ContentType)
+		if contentType == "" {
+			// TODO: need to test for RFC 2046
+			errors = append(errors, "contentType: if present, MUST adhere to the format specified in RFC 2046")
+		}
+	}
+
+	// extensions
+	// Type: Map
+	// Constraints:
+	// 	OPTIONAL
+	// 	If present, MUST contain at least one entry
+	if ec.Extensions != nil {
+		if len(ec.Extensions) == 0 {
+			errors = append(errors, "extensions: if present, MUST contain at least one entry")
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf(strings.Join(errors, "\n"))
+	}
+	return nil
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v03.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v03.go
@@ -1,7 +1,11 @@
 package cloudevents
 
 import (
+	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"log"
+	"mime"
+	"strings"
 )
 
 // WIP: AS OF FEB 19, 2019
@@ -26,9 +30,9 @@ type EventContextV03 struct {
 	Time *types.Timestamp `json:"time,omitempty"`
 	// SchemaURL - A link to the schema that the `data` attribute adheres to.
 	SchemaURL *types.URLRef `json:"schemaurl,omitempty"`
-	// GetDataContentType - A MIME (RFC2046) string describing the media type of `data`.
+	// GetDataMediaType - A MIME (RFC2046) string describing the media type of `data`.
 	// TODO: Should an empty string assume `application/json`, `application/octet-stream`, or auto-detect the content?
-	DataContentType string `json:"datacontenttype,omitempty"`
+	DataContentType *string `json:"datacontenttype,omitempty"`
 	// Extensions - Additional extension metadata beyond the base spec.
 	Extensions map[string]interface{} `json:"-,omitempty"` // TODO: decide how we want extensions to be inserted
 }
@@ -43,9 +47,23 @@ func (ec EventContextV03) GetSpecVersion() string {
 }
 
 func (ec EventContextV03) GetDataContentType() string {
-	return ec.DataContentType
+	if ec.DataContentType != nil {
+		return *ec.DataContentType
+	}
+	return ""
 }
 
+func (ec EventContextV03) GetDataMediaType() string {
+	if ec.DataContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
+		if err != nil {
+			log.Printf("failed to parse media type from DataContentType: %s", err)
+			return ""
+		}
+		return mediaType
+	}
+	return ""
+}
 func (ec EventContextV03) GetType() string {
 	return ec.Type
 }
@@ -72,4 +90,92 @@ func (ec EventContextV03) AsV02() EventContextV02 {
 func (ec EventContextV03) AsV03() EventContextV03 {
 	ec.SpecVersion = CloudEventsVersionV03
 	return ec
+}
+
+// Validate returns errors based on requirements from the CloudEvents spec.
+// For more details, see https://github.com/cloudevents/spec/blob/master/spec.md
+// As of Feb 26, 2019, commit 17c32ea26baf7714ad027d9917d03d2fff79fc7e
+func (ec EventContextV03) Validate() error {
+	errors := []string(nil)
+
+	// type
+	// Type: String
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty string
+	//  SHOULD be prefixed with a reverse-DNS name. The prefixed domain dictates the organization which defines the semantics of this event type.
+	eventType := strings.TrimSpace(ec.Type)
+	if eventType == "" {
+		errors = append(errors, "type: MUST be a non-empty string")
+	}
+
+	// specversion
+	// Type: String
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty string
+	specVersion := strings.TrimSpace(ec.SpecVersion)
+	if specVersion == "" {
+		errors = append(errors, "specversion: MUST be a non-empty string")
+	}
+
+	// source
+	// Type: URI-reference
+	// Constraints:
+	//  REQUIRED
+	source := strings.TrimSpace(ec.Source.String())
+	if source == "" {
+		errors = append(errors, "source: REQUIRED")
+	}
+
+	// id
+	// Type: String
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty string
+	//  MUST be unique within the scope of the producer
+	id := strings.TrimSpace(ec.ID)
+	if id == "" {
+		errors = append(errors, "id: MUST be a non-empty string")
+
+		// no way to test "MUST be unique within the scope of the producer"
+	}
+
+	// time
+	// Type: Timestamp
+	// Constraints:
+	//  OPTIONAL
+	//  If present, MUST adhere to the format specified in RFC 3339
+	// --> no need to test this, no way to set the time without it being valid.
+
+	// schemaurl
+	// Type: URI
+	// Constraints:
+	//  OPTIONAL
+	//  If present, MUST adhere to the format specified in RFC 3986
+	if ec.SchemaURL != nil {
+		schemaURL := strings.TrimSpace(ec.SchemaURL.String())
+		// empty string is not RFC 3986 compatible.
+		if schemaURL == "" {
+			errors = append(errors, "schemaurl: if present, MUST adhere to the format specified in RFC 3986")
+		}
+	}
+
+	// datacontenttype
+	// Type: String per RFC 2046
+	// Constraints:
+	//  OPTIONAL
+	//  If present, MUST adhere to the format specified in RFC 2046
+	if ec.DataContentType != nil {
+		dataContentType := strings.TrimSpace(*ec.DataContentType)
+		if dataContentType == "" {
+			// TODO: need to test for RFC 2046
+			errors = append(errors, "datacontenttype: if present, MUST adhere to the format specified in RFC 2046")
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf(strings.Join(errors, "\n"))
+	}
+	return nil
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/encoding.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/encoding.go
@@ -14,10 +14,6 @@ const (
 	Unknown
 )
 
-const (
-	CloudEventsStructuredMediaType string = "application/cloudevents+json"
-)
-
 func (e Encoding) String() string {
 	switch e {
 	case Default:
@@ -50,6 +46,8 @@ func (e Encoding) String() string {
 
 func (e Encoding) Version() string {
 	switch e {
+	case Default:
+		return "Default"
 
 	// Version 0.1
 	case BinaryV01:
@@ -58,8 +56,6 @@ func (e Encoding) Version() string {
 		return "v0.1"
 
 	// Version 0.2
-	case Default: // <-- Move when a new default is wanted.
-		fallthrough
 	case BinaryV02:
 		fallthrough
 	case StructuredV02:


### PR DESCRIPTION
Update cloudevent sdk to include auto-generated uuid options. This simplifies the client context generation.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE.
```