### PR TITLE
migrate github, awssqs, cron, and websocket sources to new cloudevents sdk v0.2

### DIFF
--- a/cmd/heartbeats_receiver/main.go
+++ b/cmd/heartbeats_receiver/main.go
@@ -37,11 +37,7 @@ func receive(event cloudevents.Event) {
 		fmt.Printf("got data error: %s\n", err.Error())
 	}
 	log.Printf("CloudEvent:\n%s", event)
-<<<<<<< HEAD
 	log.Printf("[%s] %s %s: ", ec.Time, event.DataContentType(), ec.Source.String())
-=======
-	log.Printf("[%s] %s %s: ", ec.Time, ec.ContentType, ec.Source.String())
->>>>>>> Update cloudevent sdk to include auto-generated uuid options.
 	log.Printf("\t%d, %q", hb.Sequence, hb.Label)
 }
 

--- a/cmd/heartbeats_receiver/main.go
+++ b/cmd/heartbeats_receiver/main.go
@@ -37,7 +37,11 @@ func receive(event cloudevents.Event) {
 		fmt.Printf("got data error: %s\n", err.Error())
 	}
 	log.Printf("CloudEvent:\n%s", event)
+<<<<<<< HEAD
 	log.Printf("[%s] %s %s: ", ec.Time, event.DataContentType(), ec.Source.String())
+=======
+	log.Printf("[%s] %s %s: ", ec.Time, ec.ContentType, ec.Source.String())
+>>>>>>> Update cloudevent sdk to include auto-generated uuid options.
 	log.Printf("\t%d, %q", hb.Sequence, hb.Label)
 }
 

--- a/pkg/adapter/cronjobevents/adapter_test.go
+++ b/pkg/adapter/cronjobevents/adapter_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2018 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/adapter/github/adapter.go
+++ b/pkg/adapter/github/adapter.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,13 +17,18 @@ limitations under the License.
 package github
 
 import (
+	"context"
 	"fmt"
+
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+
 	"log"
 	"net/http"
 
-	"github.com/google/uuid"
 	sourcesv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
-	"github.com/knative/pkg/cloudevents"
+
 	webhooks "gopkg.in/go-playground/webhooks.v3"
 	gh "gopkg.in/go-playground/webhooks.v3/github"
 )
@@ -37,7 +42,7 @@ const (
 // then sends them to the specified Sink
 type Adapter struct {
 	Sink   string
-	client *cloudevents.Client
+	client client.Client
 }
 
 // HandleEvent is invoked whenever an event comes in from GitHub
@@ -51,133 +56,150 @@ func (ra *Adapter) HandleEvent(payload interface{}, header webhooks.Header) {
 
 func (ra *Adapter) handleEvent(payload interface{}, hdr http.Header) error {
 	if ra.client == nil {
-		ra.client = cloudevents.NewClient(ra.Sink, cloudevents.Builder{})
+		var err error
+		if ra.client, err = client.NewHTTPClient(
+			client.WithTarget(ra.Sink),
+			client.WithHTTPBinaryEncoding(),
+			client.WithUUIDs(),
+			client.WithTimeNow(),
+		); err != nil {
+			return err
+		}
 	}
 
 	gitHubEventType := hdr.Get("X-" + GHHeaderEvent)
 	eventID := hdr.Get("X-" + GHHeaderDelivery)
 	extensions := map[string]interface{}{
-		GHHeaderEvent:    hdr.Get("X-" + GHHeaderEvent),
-		GHHeaderDelivery: hdr.Get("X-" + GHHeaderDelivery),
+		GHHeaderEvent:    gitHubEventType,
+		GHHeaderDelivery: eventID,
 	}
 
 	log.Printf("Handling %s", gitHubEventType)
 
-	if len(eventID) == 0 {
-		if uuid, err := uuid.NewRandom(); err == nil {
-			eventID = uuid.String()
-		}
+	cloudEventType := fmt.Sprintf("%s.%s", sourcesv1alpha1.GitHubSourceEventPrefix, gitHubEventType)
+	source, err := sourceFromGitHubEvent(gh.Event(gitHubEventType), payload)
+	if err != nil {
+		return err
 	}
 
-	cloudEventType := fmt.Sprintf("%s.%s", sourcesv1alpha1.GitHubSourceEventPrefix, gitHubEventType)
-	source := sourceFromGitHubEvent(gh.Event(gitHubEventType), payload)
-
-	return ra.client.Send(payload, cloudevents.V01EventContext{
-		EventType:  cloudEventType,
-		EventID:    eventID,
-		Source:     source,
-		Extensions: extensions,
-	})
+	event := cloudevents.Event{
+		Context: cloudevents.EventContextV02{
+			ID:         eventID,
+			Type:       cloudEventType,
+			Source:     *source,
+			Extensions: extensions,
+		}.AsV02(),
+		Data: payload,
+	}
+	return ra.client.Send(context.TODO(), event)
 }
 
-func sourceFromGitHubEvent(gitHubEvent gh.Event, payload interface{}) string {
+func sourceFromGitHubEvent(gitHubEvent gh.Event, payload interface{}) (*types.URLRef, error) {
+	var url string
 	switch gitHubEvent {
 	case gh.CommitCommentEvent:
 		cc := payload.(gh.CommitCommentPayload)
-		return cc.Comment.HTMLURL
+		url = cc.Comment.HTMLURL
 	case gh.CreateEvent:
 		c := payload.(gh.CreatePayload)
-		return c.Repository.HTMLURL
+		url = c.Repository.HTMLURL
 	case gh.DeleteEvent:
 		d := payload.(gh.DeletePayload)
-		return d.Repository.HTMLURL
+		url = d.Repository.HTMLURL
 	case gh.DeploymentEvent:
 		d := payload.(gh.DeploymentPayload)
-		return d.Repository.HTMLURL
+		url = d.Repository.HTMLURL
 	case gh.DeploymentStatusEvent:
 		d := payload.(gh.DeploymentStatusPayload)
-		return d.Repository.HTMLURL
+		url = d.Repository.HTMLURL
 	case gh.ForkEvent:
 		f := payload.(gh.ForkPayload)
-		return f.Forkee.HTMLURL
+		url = f.Forkee.HTMLURL
 	case gh.GollumEvent:
 		g := payload.(gh.GollumPayload)
-		return g.Repository.HTMLURL
+		url = g.Repository.HTMLURL
 	case gh.InstallationEvent, gh.IntegrationInstallationEvent:
 		i := payload.(gh.InstallationPayload)
-		return i.Installation.HTMLURL
+		url = i.Installation.HTMLURL
 	case gh.IssueCommentEvent:
 		i := payload.(gh.IssueCommentPayload)
-		return i.Comment.HTMLURL
+		url = i.Comment.HTMLURL
 	case gh.IssuesEvent:
 		i := payload.(gh.IssuesPayload)
-		return i.Issue.HTMLURL
+		url = i.Issue.HTMLURL
 	case gh.LabelEvent:
 		l := payload.(gh.LabelPayload)
-		return l.Repository.HTMLURL
+		url = l.Repository.HTMLURL
 	case gh.MemberEvent:
 		m := payload.(gh.MemberPayload)
-		return m.Repository.HTMLURL
+		url = m.Repository.HTMLURL
 	case gh.MembershipEvent:
 		m := payload.(gh.MembershipPayload)
-		return m.Organization.URL
+		url = m.Organization.URL
 	case gh.MilestoneEvent:
 		m := payload.(gh.MilestonePayload)
-		return m.Repository.HTMLURL
+		url = m.Repository.HTMLURL
 	case gh.OrganizationEvent:
 		o := payload.(gh.OrganizationPayload)
-		return o.Organization.URL
+		url = o.Organization.URL
 	case gh.OrgBlockEvent:
 		o := payload.(gh.OrgBlockPayload)
-		return o.Organization.URL
+		url = o.Organization.URL
 	case gh.PageBuildEvent:
 		p := payload.(gh.PageBuildPayload)
-		return p.Repository.HTMLURL
+		url = p.Repository.HTMLURL
 	case gh.PingEvent:
 		p := payload.(gh.PingPayload)
-		return p.Hook.Config.URL
+		url = p.Hook.Config.URL
 	case gh.ProjectCardEvent:
 		p := payload.(gh.ProjectCardPayload)
-		return p.Repository.HTMLURL
+		url = p.Repository.HTMLURL
 	case gh.ProjectColumnEvent:
 		p := payload.(gh.ProjectColumnPayload)
-		return p.Repository.HTMLURL
+		url = p.Repository.HTMLURL
 	case gh.ProjectEvent:
 		p := payload.(gh.ProjectPayload)
-		return p.Repository.HTMLURL
+		url = p.Repository.HTMLURL
 	case gh.PublicEvent:
 		p := payload.(gh.PublicPayload)
-		return p.Repository.HTMLURL
+		url = p.Repository.HTMLURL
 	case gh.PullRequestEvent:
 		p := payload.(gh.PullRequestPayload)
-		return p.PullRequest.HTMLURL
+		url = p.PullRequest.HTMLURL
 	case gh.PullRequestReviewEvent:
 		p := payload.(gh.PullRequestReviewPayload)
-		return p.Review.HTMLURL
+		url = p.Review.HTMLURL
 	case gh.PullRequestReviewCommentEvent:
 		p := payload.(gh.PullRequestReviewCommentPayload)
-		return p.Comment.HTMLURL
+		url = p.Comment.HTMLURL
 	case gh.PushEvent:
 		p := payload.(gh.PushPayload)
-		return p.Compare
+		url = p.Compare
 	case gh.ReleaseEvent:
 		r := payload.(gh.ReleasePayload)
-		return r.Release.HTMLURL
+		url = r.Release.HTMLURL
 	case gh.RepositoryEvent:
 		r := payload.(gh.RepositoryPayload)
-		return r.Repository.HTMLURL
+		url = r.Repository.HTMLURL
 	case gh.StatusEvent:
 		s := payload.(gh.StatusPayload)
-		return s.Commit.HTMLURL
+		url = s.Commit.HTMLURL
 	case gh.TeamEvent:
 		t := payload.(gh.TeamPayload)
-		return t.Organization.URL
+		url = t.Organization.URL
 	case gh.TeamAddEvent:
 		t := payload.(gh.TeamAddPayload)
-		return t.Repository.HTMLURL
+		url = t.Repository.HTMLURL
 	case gh.WatchEvent:
 		w := payload.(gh.WatchPayload)
-		return w.Repository.HTMLURL
+		url = w.Repository.HTMLURL
 	}
-	return ""
+	if url != "" {
+		source := types.ParseURLRef(url)
+		if source != nil {
+			return source, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no source found in github event")
 }

--- a/pkg/adapter/github/adapter_test.go
+++ b/pkg/adapter/github/adapter_test.go
@@ -73,7 +73,7 @@ var testCases = []testCase{
 		name:       "no source",
 		payload:    gh.PullRequestPayload{},
 		eventType:  "pull_request",
-		wantErrMsg: `ctx.Source resolved empty`,
+		wantErrMsg: `no source found in github event`,
 	}, {
 		name: "valid commit_comment",
 		payload: func() interface{} {
@@ -502,7 +502,7 @@ var (
 		"accept-encoding": {},
 		"content-length":  {},
 		"user-agent":      {},
-		"ce-eventtime":    {},
+		"ce-time":         {},
 	}
 )
 
@@ -518,13 +518,13 @@ func TestHandleEvent(t *testing.T) {
 
 	expectedRequest := requestValidation{
 		Headers: map[string][]string{
-			"ce-cloudeventsversion": {"0.1"},
-			"ce-eventid":            {"12345"},
-			"ce-eventtime":          {"2019-01-29T09:35:10.69383396-08:00"},
-			"ce-eventtype":          {"dev.knative.source.github.pull_request"},
-			"ce-source":             {"http://github.com/a/b"},
-			"ce-x-github-delivery":  {`"12345"`},
-			"ce-x-github-event":     {`"pull_request"`},
+			"ce-specversion":     {"0.2"},
+			"ce-id":              {"12345"},
+			"ce-time":            {"2019-01-29T09:35:10.69383396-08:00"},
+			"ce-type":            {"dev.knative.source.github.pull_request"},
+			"ce-source":          {"http://github.com/a/b"},
+			"ce-github-delivery": {`"12345"`},
+			"ce-github-event":    {`"pull_request"`},
 
 			"content-type": {"application/json"},
 		},


### PR DESCRIPTION
## Proposed Changes
  *	Updated websocket source to cloudevents v0.2 and new sdk.
  *	Updated awssqs source to cloudevents v0.2 and new sdk.
  *	Updated cronjobevents source  to cloudevents v0.2 and new sdk.
  *	Updated github to cloudevents v0.2 and new sdk.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
  *	Updated websocket source to cloudevents v0.2 and new sdk.
  *	Updated awssqs source to cloudevents v0.2 and new sdk.
  *	Updated cronjobevents source  to cloudevents v0.2 and new sdk.
  *	Updated github to cloudevents v0.2 and new sdk.
```