### PR TITLE
Fix invalid log format from cronjob source

### DIFF
--- a/cmd/cronjob_receive_adapter/main.go
+++ b/cmd/cronjob_receive_adapter/main.go
@@ -66,11 +66,11 @@ func main() {
 		SinkURI:  getRequiredEnv(envSinkURI),
 	}
 
-	logger.Info("Starting Receive Adapter. %v", zap.Reflect("adapter", adapter))
+	logger.Info("Starting Receive Adapter", zap.Reflect("adapter", adapter))
 
 	stopCh := signals.SetupSignalHandler()
 
 	if err := adapter.Start(ctx, stopCh); err != nil {
-		logger.Fatal("Failed to start adapter: ", zap.Error(err))
+		logger.Fatal("Failed to start adapter", zap.Error(err))
 	}
 }


### PR DESCRIPTION
## Proposed Changes

cronjob source outptus message contains raw `%v` as:

```
$ kubectl logs cronjob-test-cronjob-source-bdf82-65c44698b5-rrhn4 -c receive-adapter
{..."msg":"Starting Receive Adapter. %v","adapter":{"Schedule":"* * * * *","Data":"{\"message\": \"Hello world!\"}","SinkURI":"http://cj-1-channel-fndzv.default.svc.cluster.local/"}}
```

This patch removes the raw `%v`.

**Release Note**
```release-note
NONE
```