### PR TITLE
Display error message for creating cloudevent client to make it more debug friendly

### DIFF
--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -76,7 +76,7 @@ func (a *Adapter) cronTick() {
 			client.WithUUIDs(),
 			client.WithTimeNow(),
 		); err != nil {
-			logger.Info("Failed to create cloudevent client.")
+			logger.Info("Failed to create cloudevent client", err)
 			return
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

Error message from `client.NewHTTPClient()` is disregarded. This patch
displays the message to make it more debug friendly.

**Release Note**
```release-note
NONE
```