### PR TITLE
Fix wrong namespace to create event-sources in REDME

### DIFF
--- a/samples/cronjob-source/README.md
+++ b/samples/cronjob-source/README.md
@@ -25,7 +25,7 @@
    controller.
 
    ```shell
-   ko -n default apply -f config/
+   ko apply -f config/
    ```
 
    - Note that if the `Source` Service Account secret is in a non-default


### PR DESCRIPTION
## Proposed Changes

Manifests under `config/` directory should be created against
`knative-sources` namespace. But as docs instructs to specifies `-n
default`, it fails to create them.

- actually error message:
```
$ ko -n default apply -f config/
  ...
the namespace from the provided object "knative-sources" does not match the namespace "default". You must pass '--namespace=knative-sources' to perform this operation.

$ ko -n default apply -f config/400-controller-service.yaml 
error: the namespace from the provided object "knative-sources" does not match the namespace "default". You must pass '--namespace=knative-sources' to perform this operation.
2019/03/07 20:55:37 error executing 'kubectl apply': exit status 1
```

This patch fixes the docs.

**Release Note**
```release-note
NONE
```