### PR TITLE
Correct release artifacts in release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -19,17 +19,16 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["sources.yaml"]="config"
+  ["release.yaml"]="config"
   ["gcppubsub.yaml"]="contrib/gcppubsub/config"
   ["message-dumper.yaml"]="config/tools/message-dumper"
 )
 readonly COMPONENTS
 
+# Yaml files that are combinations of the above components. Release files must
+# not have the same name as any component files.
 declare -A RELEASES
 RELEASES=(
-  ["release.yaml"]="sources.yaml"
-  ["gcppubsub.yaml"]="gcppubsub.yaml"
-  ["message-dumper.yaml"]="message-dumper.yaml"
 )
 readonly RELEASES
 


### PR DESCRIPTION
"Releases" as defined by release.sh are combinations of components. Eventing Sources releases don't have any of those.

Since components and releases share a namespace, releases cannot have
the same name as any components. This caused https://github.com/knative/eventing-sources/issues/213 as explained in https://github.com/knative/eventing-sources/issues/213#issuecomment-470654486.

Fixes #213

## Proposed Changes

  * Remove the `sources.yaml` release artifact.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
The sources.yaml artifact accidentally uploaded as part of release 0.4.0 was removed.
```