### PR TITLE
Fix race condition for creating cloudevent client

### DIFF
--- a/pkg/adapter/awssqs/adapter.go
+++ b/pkg/adapter/awssqs/adapter.go
@@ -99,8 +99,7 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 
 	logger.Info("Starting with config: ", zap.Any("adapter", a))
 
-	err := a.initClient()
-	if err != nil {
+	if err := a.initClient(); err != nil {
 		logger.Error("Failed to create cloudevent client", zap.Error(err))
 		return err
 	}

--- a/pkg/adapter/awssqs/adapter.go
+++ b/pkg/adapter/awssqs/adapter.go
@@ -77,11 +77,33 @@ func getRegion(url string) (string, error) {
 	return parts[1], nil
 }
 
+// Initialize cloudevent client
+func (a *Adapter) initClient() error {
+	if a.client == nil {
+		var err error
+		if a.client, err = client.NewHTTPClient(
+			client.WithTarget(a.SinkURI),
+			client.WithHTTPBinaryEncoding(),
+			client.WithUUIDs(),
+			client.WithTimeNow(),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 
 	logger := logging.FromContext(ctx)
 
 	logger.Info("Starting with config: ", zap.Any("adapter", a))
+
+	err := a.initClient()
+	if err != nil {
+		logger.Error("Failed to create cloudevent client", zap.Error(err))
+		return err
+	}
 
 	region, err := getRegion(a.QueueURL)
 	if err != nil {
@@ -155,18 +177,6 @@ func (a *Adapter) receiveMessage(ctx context.Context, m *sqs.Message, ack func()
 
 // postMessage sends an SQS event to the SinkURI
 func (a *Adapter) postMessage(ctx context.Context, logger *zap.SugaredLogger, m *sqs.Message) error {
-	if a.client == nil {
-
-		var err error
-		if a.client, err = client.NewHTTPClient(
-			client.WithTarget(a.SinkURI),
-			client.WithHTTPBinaryEncoding(),
-			client.WithUUIDs(),
-			client.WithTimeNow(),
-		); err != nil {
-			return err
-		}
-	}
 
 	// TODO verify the timestamp conversion
 	timestamp, err := strconv.ParseInt(*m.Attributes["SentTimestamp"], 10, 64)

--- a/pkg/adapter/awssqs/adapter_test.go
+++ b/pkg/adapter/awssqs/adapter_test.go
@@ -59,8 +59,7 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 				OnFailedPollWaitSecs: 1,
 			}
 
-			err := a.initClient()
-			if err != nil {
+			if err := a.initClient(); err != nil {
 				t.Errorf("failed to create cloudevent client, %v", err)
 			}
 
@@ -74,7 +73,7 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 				Body:       &body,
 				Attributes: attrs,
 			}
-			err = a.postMessage(context.TODO(), zap.S(), m)
+			err := a.postMessage(context.TODO(), zap.S(), m)
 
 			if tc.error && err == nil {
 				t.Errorf("expected error, but got %v", err)
@@ -139,8 +138,7 @@ func TestReceiveMessage_ServeHTTP(t *testing.T) {
 				SinkURI:  sinkServer.URL,
 			}
 
-			err := a.initClient()
-			if err != nil {
+			if err := a.initClient(); err != nil {
 				t.Errorf("failed to create cloudevent client, %v", err)
 			}
 

--- a/pkg/adapter/awssqs/adapter_test.go
+++ b/pkg/adapter/awssqs/adapter_test.go
@@ -59,6 +59,11 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 				OnFailedPollWaitSecs: 1,
 			}
 
+			err := a.initClient()
+			if err != nil {
+				t.Errorf("failed to create cloudevent client, %v", err)
+			}
+
 			body := "The body"
 			messageId := "ABC01"
 			attrs := map[string]*string{
@@ -69,7 +74,7 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 				Body:       &body,
 				Attributes: attrs,
 			}
-			err := a.postMessage(context.TODO(), zap.S(), m)
+			err = a.postMessage(context.TODO(), zap.S(), m)
 
 			if tc.error && err == nil {
 				t.Errorf("expected error, but got %v", err)
@@ -132,6 +137,11 @@ func TestReceiveMessage_ServeHTTP(t *testing.T) {
 			a := &Adapter{
 				QueueURL: "https://sqs.us-east-2.amazonaws.com/123123/MyQueue",
 				SinkURI:  sinkServer.URL,
+			}
+
+			err := a.initClient()
+			if err != nil {
+				t.Errorf("failed to create cloudevent client, %v", err)
 			}
 
 			ack := new(bool)

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -74,8 +74,7 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 		return err
 	}
 
-	err = a.initClient()
-	if err != nil {
+	if err = a.initClient(); err != nil {
 		logger.Error("Failed to create cloudevent client", zap.Error(err))
 		return err
 	}

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -49,6 +49,22 @@ type Adapter struct {
 	client client.Client
 }
 
+// Initialize cloudevent client
+func (a *Adapter) initClient() error {
+	if a.client == nil {
+		var err error
+		if a.client, err = client.NewHTTPClient(
+			client.WithTarget(a.SinkURI),
+			client.WithHTTPBinaryEncoding(),
+			client.WithUUIDs(),
+			client.WithTimeNow(),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 	logger := logging.FromContext(ctx)
 
@@ -57,6 +73,13 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 		logger.Error("Unparseable schedule: ", a.Schedule, zap.Error(err))
 		return err
 	}
+
+	err = a.initClient()
+	if err != nil {
+		logger.Error("Failed to create cloudevent client", zap.Error(err))
+		return err
+	}
+
 	c := cron.New()
 	c.Schedule(sched, cron.FuncJob(a.cronTick))
 	c.Start()
@@ -68,18 +91,7 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 
 func (a *Adapter) cronTick() {
 	logger := logging.FromContext(context.TODO())
-	if a.client == nil {
-		var err error
-		if a.client, err = client.NewHTTPClient(
-			client.WithTarget(a.SinkURI),
-			client.WithHTTPBinaryEncoding(),
-			client.WithUUIDs(),
-			client.WithTimeNow(),
-		); err != nil {
-			logger.Info("Failed to create cloudevent client.")
-			return
-		}
-	}
+
 	event := cloudevents.Event{
 		Context: cloudevents.EventContextV02{
 			Type:   eventType,

--- a/pkg/adapter/cronjobevents/adapter_test.go
+++ b/pkg/adapter/cronjobevents/adapter_test.go
@@ -61,8 +61,7 @@ func TestStart_ServeHTTP(t *testing.T) {
 				SinkURI:  sinkServer.URL,
 			}
 
-			err := a.initClient()
-			if err != nil {
+			if err := a.initClient(); err != nil {
 				t.Errorf("failed to create cloudevent client, %v", err)
 			}
 
@@ -131,8 +130,7 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 				SinkURI: sinkServer.URL,
 			}
 
-			err := a.initClient()
-			if err != nil {
+			if err := a.initClient(); err != nil {
 				t.Errorf("failed to create cloudevent client, %v", err)
 			}
 

--- a/pkg/adapter/cronjobevents/adapter_test.go
+++ b/pkg/adapter/cronjobevents/adapter_test.go
@@ -61,6 +61,11 @@ func TestStart_ServeHTTP(t *testing.T) {
 				SinkURI:  sinkServer.URL,
 			}
 
+			err := a.initClient()
+			if err != nil {
+				t.Errorf("failed to create cloudevent client, %v", err)
+			}
+
 			stop := make(chan struct{})
 			go func() {
 				if err := a.Start(context.TODO(), stop); err != nil {
@@ -124,6 +129,11 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 			a := &Adapter{
 				Data:    "data",
 				SinkURI: sinkServer.URL,
+			}
+
+			err := a.initClient()
+			if err != nil {
+				t.Errorf("failed to create cloudevent client, %v", err)
 			}
 
 			a.cronTick()

--- a/pkg/adapter/github/adapter.go
+++ b/pkg/adapter/github/adapter.go
@@ -71,9 +71,6 @@ func (ra *Adapter) handleEvent(payload interface{}, hdr http.Header) error {
 			}
 		})
 	}
-	if ra.client == nil {
-		return fmt.Errorf("failed to create cloudevent client")
-	}
 
 	gitHubEventType := hdr.Get("X-" + GHHeaderEvent)
 	eventID := hdr.Get("X-" + GHHeaderDelivery)


### PR DESCRIPTION
Fixes #227 #206 

## Proposed Changes

  * Move client init out of PostMessage for Cronjob and AwsSqs sources
  * Use sync.Once to init client for github event source 
 

**Release Note**
No
```release-note
```