### PR TITLE
Enable specifying https github webhooks

### DIFF
--- a/pkg/apis/sources/v1alpha1/githubsource_types.go
+++ b/pkg/apis/sources/v1alpha1/githubsource_types.go
@@ -73,6 +73,10 @@ type GitHubSourceSpec struct {
 	// API URL if using github enterprise (default https://api.github.com)
 	// +optional
 	GitHubAPIURL string `json:"githubAPIURL,omitempty"`
+
+	// Secure can be set to true to configure the webhook to use https.
+	// +optional
+	Secure bool `json:"secure,omitempty"`
 }
 
 // SecretValueFromSource represents the source of a secret value

--- a/pkg/reconciler/githubsource/githubsource.go
+++ b/pkg/reconciler/githubsource/githubsource.go
@@ -227,6 +227,7 @@ func (r *reconciler) createWebhook(ctx context.Context, source *sourcesv1alpha1.
 		owner:       owner,
 		repo:        repo,
 		events:      source.Spec.EventTypes,
+		secure:      source.Spec.Secure,
 	}
 	hookID, err := r.webhookClient.Create(ctx, hookOptions, alternateGitHubAPIURL)
 	if err != nil {
@@ -261,6 +262,7 @@ func (r *reconciler) deleteWebhook(ctx context.Context, source *sourcesv1alpha1.
 		owner:       owner,
 		repo:        repo,
 		events:      source.Spec.EventTypes,
+		secure:      source.Spec.Secure,
 	}
 	err = r.webhookClient.Delete(ctx, hookOptions, hookID, alternateGitHubAPIURL)
 	if err != nil {

--- a/pkg/reconciler/githubsource/webhook_client.go
+++ b/pkg/reconciler/githubsource/webhook_client.go
@@ -34,6 +34,7 @@ type webhookOptions struct {
 	owner       string
 	repo        string
 	events      []string
+	secure      bool
 }
 
 type webhookClient interface {
@@ -122,7 +123,11 @@ func (client gitHubWebhookClient) hookConfig(ctx context.Context, options *webho
 	domain := options.domain
 	active := true
 	config := make(map[string]interface{})
-	config["url"] = fmt.Sprintf("http://%s", domain)
+	protocol := "http"
+	if options.secure {
+		protocol = "https"
+	}
+	config["url"] = fmt.Sprintf("%s://%s", protocol, domain)
 	config["content_type"] = "json"
 	config["secret"] = options.secretToken
 


### PR DESCRIPTION
## Proposed Changes

  * Add spec property `secure` which when set to true causes the webhook to be configured using https rather than the default http.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Configure https GitHub webhooks using the `secure` property.
```