### PR TITLE
Added dev info

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,8 +88,7 @@ kubectl -n knative-sources logs $(kubectl -n knative-sources get pods -l control
 
 ## Iterating
 
-As you make changes to the code-base, there are two special cases to be aware
-of:
+As you make changes to the code-base:
 
 - **If you change a package's deps** (including adding external dep), then you
   must run [`./hack/update-deps.sh`](./hack/update-deps.sh).
@@ -99,6 +98,10 @@ of:
 
 These are both idempotent, and we expect that running these in the `master`
 branch to produce no diffs.
+
+To verify that your generated code is correct with the new type definition you can run [`./hack/verify-codegen.sh`](./hack/verify-codegen.sh). On OSX you will need GNU `diff` version 3.7 that you can install from `brew` with `brew install diffutils`.
+
+To check that the build and tests passes please see the test [documentation](#tests) or simply run [`./test/presubmit-tests.sh](./test/presubmit-tests.sh)
 
 Once the codegen and dependency information is correct, redeploy using the same
 `ko apply` command you used [Installing a Source](#installing-a-source).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,7 @@ To check out this repository:
 
 1. Create your own
    [fork of this repo](https://help.github.com/articles/fork-a-repo/)
-2. Clone it to your machine:
+1. Clone it to your machine:
 
 ```shell
 mkdir -p ${GOPATH}/src/github.com/knative

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,7 +69,7 @@ ko apply -f config/
 This command is idempotent, so you can run it at any time to update your
 deployment.
 
-_See [config/README.md](./config/README.md) for instructions on installing the
+_See [contrib/gcppubsub/samples/README.md](./contrib/gcppubsub/samples/README.md) for instructions on installing the
 gcppubsub source._
 
 You can see things running with:


### PR DESCRIPTION
A few more details in the development.md as I tried to update the packages.  `diff` was not working on OSX due to missing `-no-dereference` option and the script to run tests was a bit hidden.

Fixes #

## Proposed Changes

  *
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```