### PR TITLE
Disable markdown linting in presubmits. 

### DIFF
--- a/cmd/heartbeats_receiver/main.go
+++ b/cmd/heartbeats_receiver/main.go
@@ -37,11 +37,7 @@ func receive(event cloudevents.Event) {
 		fmt.Printf("got data error: %s\n", err.Error())
 	}
 	log.Printf("CloudEvent:\n%s", event)
-<<<<<<< HEAD
 	log.Printf("[%s] %s %s: ", ec.Time, event.DataContentType(), ec.Source.String())
-=======
-	log.Printf("[%s] %s %s: ", ec.Time, ec.ContentType, ec.Source.String())
->>>>>>> Update cloudevent sdk to include auto-generated uuid options.
 	log.Printf("\t%d, %q", hb.Sequence, hb.Label)
 }
 

--- a/cmd/heartbeats_receiver/main.go
+++ b/cmd/heartbeats_receiver/main.go
@@ -37,7 +37,11 @@ func receive(event cloudevents.Event) {
 		fmt.Printf("got data error: %s\n", err.Error())
 	}
 	log.Printf("CloudEvent:\n%s", event)
+<<<<<<< HEAD
 	log.Printf("[%s] %s %s: ", ec.Time, event.DataContentType(), ec.Source.String())
+=======
+	log.Printf("[%s] %s %s: ", ec.Time, ec.ContentType, ec.Source.String())
+>>>>>>> Update cloudevent sdk to include auto-generated uuid options.
 	log.Printf("\t%d, %q", hb.Sequence, hb.Label)
 }
 

--- a/test/markdown-lint-config.rc
+++ b/test/markdown-lint-config.rc
@@ -1,8 +1,0 @@
-# For help, see
-# https://github.com/markdownlint/markdownlint/blob/master/docs/configuration.md 
-
-# Ignoring some of the available rules. For more, see
-# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
-
-rules "~MD013", "~MD024"
-

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -21,6 +21,10 @@
 # Use the flags --build-tests, --unit-tests and --integration-tests
 # to run a specific set of tests.
 
+# Markdown linting failures don't show up properly in Gubernator resulting
+# in a net-negative contributor experience.
+export DISABLE_MD_LINTING=1
+
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION
Proposed Changes
Removes markdown linting in favor of the sockpuppet. #862 has hard tabs in the go code (as is appropriate for go code) referenced in the markdown file. prettier.io is fine with this and formats correctly. The linter does not. I see three ways forward:
Replace tabs with spaces in the go code, requiring reformatting it when copy-pasting.
Add MD10 to the set of exceptions, allowing a mix of tabs and spaces everywhere in markdown.
Remove the linter that randomly breaks submits, where the error reporting is not clear about the problem, and adds extra human toil to comply (vs sockpuppet, which just adds toil to approve the fixups, which are very easy to review).