### PR TITLE
golang format tools

### DIFF
--- a/cmd/heartbeats/main.go
+++ b/cmd/heartbeats/main.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/knative/eventing-sources/pkg/kncloudevents"
 	"log"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/knative/eventing-sources/pkg/kncloudevents"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"

--- a/cmd/heartbeats_receiver/main.go
+++ b/cmd/heartbeats_receiver/main.go
@@ -19,8 +19,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/knative/eventing-sources/pkg/kncloudevents"
 	"log"
+
+	"github.com/knative/eventing-sources/pkg/kncloudevents"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 )

--- a/cmd/websocketsource/main.go
+++ b/cmd/websocketsource/main.go
@@ -19,8 +19,9 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/knative/eventing-sources/pkg/kncloudevents"
 	"log"
+
+	"github.com/knative/eventing-sources/pkg/kncloudevents"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"

--- a/contrib/camel/pkg/reconciler/camelsource_test.go
+++ b/contrib/camel/pkg/reconciler/camelsource_test.go
@@ -27,7 +27,7 @@ import (
 	controllertesting "github.com/knative/eventing-sources/pkg/controller/testing"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"go.uber.org/zap"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/contrib/camel/pkg/reconciler/resources/context.go
+++ b/contrib/camel/pkg/reconciler/resources/context.go
@@ -18,7 +18,7 @@ package resources
 
 import (
 	camelv1alpha1 "github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func MakeContext(namespace string, image string) *camelv1alpha1.IntegrationContext {
@@ -31,7 +31,7 @@ func MakeContext(namespace string, image string) *camelv1alpha1.IntegrationConte
 			GenerateName: "ctx-",
 			Namespace:    namespace,
 			Labels: map[string]string{
-				"app": "camel-k",
+				"app":                           "camel-k",
 				"camel.apache.org/context.type": camelv1alpha1.IntegrationContextTypeExternal,
 			},
 		},

--- a/contrib/camel/pkg/reconciler/resources/platform.go
+++ b/contrib/camel/pkg/reconciler/resources/platform.go
@@ -18,7 +18,7 @@ package resources
 
 import (
 	camelv1alpha1 "github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/contrib/camel/pkg/reconciler/resources/source.go
+++ b/contrib/camel/pkg/reconciler/resources/source.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"errors"
+
 	camelv1alpha1 "github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	"github.com/knative/eventing-sources/contrib/camel/pkg/apis/sources/v1alpha1"
 )

--- a/contrib/gcppubsub/pkg/adapter/adapter.go
+++ b/contrib/gcppubsub/pkg/adapter/adapter.go
@@ -18,6 +18,7 @@ package gcppubsub
 
 import (
 	"fmt"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"

--- a/contrib/gcppubsub/pkg/adapter/adapter_test.go
+++ b/contrib/gcppubsub/pkg/adapter/adapter_test.go
@@ -19,12 +19,13 @@ package gcppubsub
 import (
 	"context"
 	"encoding/json"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	"github.com/knative/eventing-sources/pkg/kncloudevents"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
+	"github.com/knative/eventing-sources/pkg/kncloudevents"
 
 	"cloud.google.com/go/pubsub"
 	"go.uber.org/zap"

--- a/pkg/adapter/awssqs/adapter.go
+++ b/pkg/adapter/awssqs/adapter.go
@@ -18,10 +18,11 @@ package awssqs
 
 import (
 	"fmt"
-	"github.com/knative/eventing-sources/pkg/kncloudevents"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/knative/eventing-sources/pkg/kncloudevents"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -19,6 +19,7 @@ package cronjobevents
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/knative/eventing-sources/pkg/kncloudevents"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"

--- a/pkg/adapter/github/adapter_test.go
+++ b/pkg/adapter/github/adapter_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
-	"gopkg.in/go-playground/webhooks.v3"
+	webhooks "gopkg.in/go-playground/webhooks.v3"
 	gh "gopkg.in/go-playground/webhooks.v3/github"
 )
 

--- a/pkg/adapter/kubernetesevents/adapter.go
+++ b/pkg/adapter/kubernetesevents/adapter.go
@@ -19,8 +19,9 @@ package kubernetesevents
 import (
 	"context"
 	"fmt"
-	"github.com/knative/eventing-sources/pkg/kncloudevents"
 	"sync"
+
+	"github.com/knative/eventing-sources/pkg/kncloudevents"
 
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 

--- a/pkg/adapter/kubernetesevents/adapter_test.go
+++ b/pkg/adapter/kubernetesevents/adapter_test.go
@@ -18,14 +18,15 @@ package kubernetesevents
 
 import (
 	"fmt"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	"github.com/knative/eventing-sources/pkg/kncloudevents"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
+	"github.com/knative/eventing-sources/pkg/kncloudevents"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
