### PR TITLE
Format markdown

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,8 +69,9 @@ ko apply -f config/
 This command is idempotent, so you can run it at any time to update your
 deployment.
 
-_See [contrib/gcppubsub/samples/README.md](./contrib/gcppubsub/samples/README.md) for instructions on installing the
-gcppubsub source._
+_See
+[contrib/gcppubsub/samples/README.md](./contrib/gcppubsub/samples/README.md) for
+instructions on installing the gcppubsub source._
 
 You can see things running with:
 
@@ -99,9 +100,14 @@ As you make changes to the code-base:
 These are both idempotent, and we expect that running these in the `master`
 branch to produce no diffs.
 
-To verify that your generated code is correct with the new type definition you can run [`./hack/verify-codegen.sh`](./hack/verify-codegen.sh). On OSX you will need GNU `diff` version 3.7 that you can install from `brew` with `brew install diffutils`.
+To verify that your generated code is correct with the new type definition you
+can run [`./hack/verify-codegen.sh`](./hack/verify-codegen.sh). On OSX you will
+need GNU `diff` version 3.7 that you can install from `brew` with
+`brew install diffutils`.
 
-To check that the build and tests passes please see the test [documentation](#tests) or simply run [`./test/presubmit-tests.sh](./test/presubmit-tests.sh)
+To check that the build and tests passes please see the test
+[documentation](#tests) or simply run
+[`./test/presubmit-tests.sh](./test/presubmit-tests.sh)
 
 Once the codegen and dependency information is correct, redeploy using the same
 `ko apply` command you used [Installing a Source](#installing-a-source).

--- a/contrib/camel/samples/README.md
+++ b/contrib/camel/samples/README.md
@@ -1,7 +1,8 @@
 # Camel Source
 
 These samples show how to configure a Camel source. It is a event source that
-can leverage one of the [250+ Apache Camel components](https://github.com/apache/camel/tree/master/components)
+can leverage one of the
+[250+ Apache Camel components](https://github.com/apache/camel/tree/master/components)
 for generating events.
 
 ## Deployment Steps
@@ -11,15 +12,19 @@ These steps assume that you have checked out the repo and have a shell in this
 
 ### Prerequisites
 
-1. Install the [Apache Camel K](https://github.com/apache/camel-k) Operator in any namespace where you want to run Camel sources.
+1. Install the [Apache Camel K](https://github.com/apache/camel-k) Operator in
+   any namespace where you want to run Camel sources.
 
-   The preferred version that is compatible with Camel sources is [Camel K v0.2.0](https://github.com/apache/camel-k/releases/tag/0.2.0).
+   The preferred version that is compatible with Camel sources is
+   [Camel K v0.2.0](https://github.com/apache/camel-k/releases/tag/0.2.0).
 
-   Installation instruction are provided on the [Apache Camel K Github repository](https://github.com/apache/camel-k#installation).
-   Documentation includes specific instructions for common Kubernetes environments, including development clusters.
+   Installation instruction are provided on the
+   [Apache Camel K Github repository](https://github.com/apache/camel-k#installation).
+   Documentation includes specific instructions for common Kubernetes
+   environments, including development clusters.
 
-1. Install the Camel Source from the [yaml files in the config dir](../config/) from
-   source:
+1. Install the Camel Source from the [yaml files in the config dir](../config/)
+   from source:
 
    ```shell
    ko apply -f ../config/
@@ -30,8 +35,10 @@ These steps assume that you have checked out the repo and have a shell in this
 ### Create a Channel and a Subscriber
 
 In order to check a `CamelSource` is fully working, we will create:
+
 - a simple Knative Service that dumps incoming messages to its log
-- a in-memory channel named `camel-test` that will buffer messages created by the event source
+- a in-memory channel named `camel-test` that will buffer messages created by
+  the event source
 - a subscription to direct messages on the test channel to the dumper service
 
 Deploy `dumper_resources.yaml`, building it from source:
@@ -42,19 +49,23 @@ ko apply -f dumper_resources.yaml
 
 ### Run a CamelSource using the Timer component
 
-The samples directory contains some sample sources that can be used to generate events.
+The samples directory contains some sample sources that can be used to generate
+events.
 
-The simplest one, that does not require additional configuration is the "timer" source.
+The simplest one, that does not require additional configuration is the "timer"
+source.
 
-If you want, you can customize the source behavior using options available in the Apache Camel documentation for the
+If you want, you can customize the source behavior using options available in
+the Apache Camel documentation for the
 [timer component](https://github.com/apache/camel/blob/master/camel-core/src/main/docs/timer-component.adoc).
-All Camel components are documented in the [Apache Camel github repository](https://github.com/apache/camel/tree/master/components).
+All Camel components are documented in the
+[Apache Camel github repository](https://github.com/apache/camel/tree/master/components).
 
 Install the [timer CamelSource](source_timer.yaml) from source:
 
-   ```shell
-   ko apply -f source_timer.yaml
-   ```
+```shell
+ko apply -f source_timer.yaml
+```
 
 We will verify that the published message was sent into the Knative eventing
 system by looking at what is downstream of the `CamelSource`.
@@ -65,38 +76,44 @@ system by looking at what is downstream of the `CamelSource`.
    kail -d camel-message-dumper --since=10m
    ```
 
-If you've deployed the timer source, you should see log lines appearing every 3 seconds.
+If you've deployed the timer source, you should see log lines appearing every 3
+seconds.
 
 ### Run a CamelSource using the Telegram component
 
-Another useful component available with Camel is the Telegram component. It can be used to forward messages of
-a [Telegram](https://telegram.org/) chat into Knative channels as events.
+Another useful component available with Camel is the Telegram component. It can
+be used to forward messages of a [Telegram](https://telegram.org/) chat into
+Knative channels as events.
 
-Before using the provided Telegram CamelSource example, you need to follow the instructions on the Telegram website for
-creating a [Telegram Bot](https://core.telegram.org/bots).
-The quickest way to create a bot is to contact the [Bot Father](https://telegram.me/botfather), another Telegram Bot,
-using your preferred Telegram client (mobile or web).
-After you create the bot, you'll receive an **authorization token** that is needed for the source to work.
+Before using the provided Telegram CamelSource example, you need to follow the
+instructions on the Telegram website for creating a
+[Telegram Bot](https://core.telegram.org/bots). The quickest way to create a bot
+is to contact the [Bot Father](https://telegram.me/botfather), another Telegram
+Bot, using your preferred Telegram client (mobile or web). After you create the
+bot, you'll receive an **authorization token** that is needed for the source to
+work.
 
-First, edit the [telegram CamelSource](source_telegram.yaml) and put the authorization token, replacing the `<put-your-token-here>` placeholder.
+First, edit the [telegram CamelSource](source_telegram.yaml) and put the
+authorization token, replacing the `<put-your-token-here>` placeholder.
 
-To reduce noise in the message dumper, you can remove the previously created timer CamelSource from the namespace:
+To reduce noise in the message dumper, you can remove the previously created
+timer CamelSource from the namespace:
 
-   ```shell
-   kubectl delete camelsource camel-timer-source
-   ```
+```shell
+kubectl delete camelsource camel-timer-source
+```
 
 Install the [telegram CamelSource](source_telegram.yaml) from source:
 
-   ```shell
-   ko apply -f source_telegram.yaml
-   ```
+```shell
+ko apply -f source_telegram.yaml
+```
 
 Start again kail and keep it open on the message dumper:
 
-   ```shell
-   kail -d camel-message-dumper --since=10m
-   ```
+```shell
+kail -d camel-message-dumper --since=10m
+```
 
-Now, you can contact your bot with any Telegram client. Each message you'll send to the bot will be
-printed by the message dumper as cloudevent.
+Now, you can contact your bot with any Telegram client. Each message you'll send
+to the bot will be printed by the message dumper as cloudevent.


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`