### PR TITLE
Development README fixes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,7 +107,7 @@ need GNU `diff` version 3.7 that you can install from `brew` with
 
 To check that the build and tests passes please see the test
 [documentation](#tests) or simply run
-[`./test/presubmit-tests.sh](./test/presubmit-tests.sh)
+[`./test/presubmit-tests.sh`](./test/presubmit-tests.sh)
 
 Once the codegen and dependency information is correct, redeploy using the same
 `ko apply` command you used [Installing a Source](#installing-a-source).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,7 +107,7 @@ need GNU `diff` version 3.7 that you can install from `brew` with
 
 To check that the build and tests passes please see the test
 [documentation](#tests) or simply run
-[`./test/presubmit-tests.sh`](./test/presubmit-tests.sh)
+[`./test/presubmit-tests.sh`](./test/presubmit-tests.sh).
 
 Once the codegen and dependency information is correct, redeploy using the same
 `ko apply` command you used [Installing a Source](#installing-a-source).


### PR DESCRIPTION
As shown below, there is a missing tick mark for syntax highlighting around the presubmit tests location in `DEVELOPMENT.md`.

<img width="854" alt="Screen Shot 2019-03-19 at 2 53 10 PM" src="https://user-images.githubusercontent.com/11520887/54633605-e3bd7d00-4a56-11e9-973b-381ce2377da9.png">

