### PR TITLE
Fix broken links to docs repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Contributor Covenant Code of Conduct
 
 Please see the Knative Community
-[Contributor Covenant Code of Conduct](https://github.com/knative/docs/blob/master/community/CODE-OF-CONDUCT.md).
+[Contributor Covenant Code of Conduct](https://github.com/knative/docs/blob/master/contributing/CODE-OF-CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,5 +2,5 @@
 
 So you want to hack on Knative Eventing Sources? Yay! Please refer to Knative's
 overall
-[contribution guidelines](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md)
+[contribution guidelines](https://github.com/knative/docs/blob/master/contributing/CONTRIBUTING.md)
 to find out how you can help.


### PR DESCRIPTION
A recent commit in the docs repo, https://github.com/knative/docs/commit/3c04f86ad7b7f937ae552a1b93eca97a5d312449, has moved the `CODE-OF-CONDUCT.md` and `CONTRIBUTING.md` to a different directly resulting in broken links.