### PR TITLE
wire labels and annotations through to the deployment

### DIFF
--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -96,16 +96,14 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) error
 
 	source.Status.InitializeConditions()
 
-	// These are the annotations / labels we always apply
-	labels := map[string]string{"source": source.Name}
-	annotations := map[string]string{"sidecar.istio.io/inject": "true"}
-
+	annotations := make(map[string]string)
 	// Then wire through any annotations / labels from the Source
 	if source.ObjectMeta.Annotations != nil {
 		for k, v := range source.ObjectMeta.Annotations {
 			annotations[k] = v
 		}
 	}
+	labels := make(map[string]string)
 	if source.ObjectMeta.Labels != nil {
 		for k, v := range source.ObjectMeta.Labels {
 			labels[k] = v

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -195,6 +195,35 @@ var testCases = []controllertesting.TestCase{
 		},
 		IgnoreTimes: true,
 	}, {
+		Name:       "valid containersource, labels and annotations given",
+		Reconciles: &sourcesv1alpha1.ContainerSource{},
+		InitialState: []runtime.Object{
+			func() runtime.Object {
+				s := getContainerSource()
+				s.Spec.Sink = nil
+				s.Spec.Args = append(s.Spec.Args, fmt.Sprintf("--sink=%s", targetURI))
+				s.ObjectMeta.Annotations = map[string]string{"annotation": "solid"}
+				s.ObjectMeta.Labels = map[string]string{"label": "soliderer"}
+				return s
+			}(),
+		},
+		ReconcileKey: fmt.Sprintf("%s/%s", testNS, containerSourceName),
+		Scheme:       scheme.Scheme,
+		WantPresent: []runtime.Object{
+			func() runtime.Object {
+				s := getContainerSource()
+				s.Spec.Sink = nil
+				s.Spec.Args = append(s.Spec.Args, fmt.Sprintf("--sink=%s", targetURI))
+				s.Status.InitializeConditions()
+				s.Status.MarkDeploying("Deploying", "Created deployment %s", deployGeneratedName)
+				s.Status.MarkSink(targetURI)
+				s.ObjectMeta.Annotations = map[string]string{"annotation": "solid"}
+				s.ObjectMeta.Labels = map[string]string{"label": "soliderer"}
+				return s
+			}(),
+		},
+		IgnoreTimes: true,
+	}, {
 		Name:       "valid containersource, sink, and deployment",
 		Reconciles: &sourcesv1alpha1.ContainerSource{},
 		InitialState: []runtime.Object{

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -543,7 +543,7 @@ func getDeployment(source *sourcesv1alpha1.ContainerSource) *appsv1.Deployment {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"source": source.Name,
+					"eventing.knative.dev/source": source.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -552,7 +552,7 @@ func getDeployment(source *sourcesv1alpha1.ContainerSource) *appsv1.Deployment {
 						"sidecar.istio.io/inject": "true",
 					},
 					Labels: map[string]string{
-						"source": source.Name,
+						"eventing.knative.dev/source": source.Name,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/reconciler/containersource/resources/arguments.go
+++ b/pkg/reconciler/containersource/resources/arguments.go
@@ -29,4 +29,6 @@ type ContainerArguments struct {
 	ServiceAccountName string
 	SinkInArgs         bool
 	Sink               string
+	Annotations        map[string]string
+	Labels             map[string]string
 }

--- a/pkg/reconciler/containersource/resources/deployment.go
+++ b/pkg/reconciler/containersource/resources/deployment.go
@@ -25,6 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const sourceLabelKey = "eventing.knative.dev/source"
+
 func MakeDeployment(org *appsv1.Deployment, args *ContainerArguments) *appsv1.Deployment {
 
 	containerArgs := []string(nil)
@@ -51,13 +53,17 @@ func MakeDeployment(org *appsv1.Deployment, args *ContainerArguments) *appsv1.De
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"source": args.Name,
+					sourceLabelKey: args.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: args.Annotations,
-					Labels:      args.Labels,
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "true",
+					},
+					Labels: map[string]string{
+						sourceLabelKey: args.Name,
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: args.ServiceAccountName,
@@ -75,6 +81,25 @@ func MakeDeployment(org *appsv1.Deployment, args *ContainerArguments) *appsv1.De
 		},
 	}
 
+	// Then wire through any annotations from the source. Not a bug by allowing
+	// the container to override Istio injection.
+	if args.Annotations != nil {
+		for k, v := range args.Annotations {
+			deploy.Spec.Template.ObjectMeta.Annotations[k] = v
+		}
+	}
+
+	// Then wire through any labels from the source. Do not allow to override
+	// our source name. This seems like it would be way errorprone by allowing
+	// the matchlabels then to not match, or we'd have to force them to match, etc.
+	// just don't allow it.
+	if args.Labels != nil {
+		for k, v := range args.Labels {
+			if k != sourceLabelKey {
+				deploy.Spec.Template.ObjectMeta.Labels[k] = v
+			}
+		}
+	}
 	return deploy
 }
 

--- a/pkg/reconciler/containersource/resources/deployment.go
+++ b/pkg/reconciler/containersource/resources/deployment.go
@@ -56,12 +56,8 @@ func MakeDeployment(org *appsv1.Deployment, args *ContainerArguments) *appsv1.De
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"sidecar.istio.io/inject": "true",
-					},
-					Labels: map[string]string{
-						"source": args.Name,
-					},
+					Annotations: args.Annotations,
+					Labels:      args.Labels,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: args.ServiceAccountName,

--- a/pkg/reconciler/containersource/resources/deployment_test.go
+++ b/pkg/reconciler/containersource/resources/deployment_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestMakeDeployment_sinknolabelsandannotations(t *testing.T) {
+func TestMakeDeployment_sinkoverrideannotationlabelnotallowed(t *testing.T) {
 	got := MakeDeployment(nil, &ContainerArguments{
 		Name:      "test-name",
 		Namespace: "test-namespace",
@@ -45,6 +45,14 @@ func TestMakeDeployment_sinknolabelsandannotations(t *testing.T) {
 		ServiceAccountName: "test-service-account",
 		SinkInArgs:         false,
 		Sink:               "test-sink",
+		Labels: map[string]string{
+			"eventing.knative.dev/source": "not-allowed",
+			"anotherlabel":                "extra-label",
+		},
+		Annotations: map[string]string{
+			"sidecar.istio.io/inject": "false",
+			"anotherannotation":       "extra-annotation",
+		},
 	})
 
 	want := &appsv1.Deployment{
@@ -59,11 +67,20 @@ func TestMakeDeployment_sinknolabelsandannotations(t *testing.T) {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"source": "test-name",
+					"eventing.knative.dev/source": "test-name",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "false",
+						"anotherannotation":       "extra-annotation",
+					},
+					Labels: map[string]string{
+						"eventing.knative.dev/source": "test-name",
+						"anotherlabel":                "extra-label",
+					},
+				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: "test-service-account",
 					Containers: []corev1.Container{
@@ -123,8 +140,6 @@ func TestMakeDeployment_sink(t *testing.T) {
 		ServiceAccountName: "test-service-account",
 		SinkInArgs:         false,
 		Sink:               "test-sink",
-		Labels:             map[string]string{"source": "test-name"},
-		Annotations:        map[string]string{"sidecar.istio.io/inject": "true"},
 	})
 
 	want := &appsv1.Deployment{
@@ -139,7 +154,7 @@ func TestMakeDeployment_sink(t *testing.T) {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"source": "test-name",
+					"eventing.knative.dev/source": "test-name",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -148,7 +163,7 @@ func TestMakeDeployment_sink(t *testing.T) {
 						"sidecar.istio.io/inject": "true",
 					},
 					Labels: map[string]string{
-						"source": "test-name",
+						"eventing.knative.dev/source": "test-name",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -209,7 +224,7 @@ func TestMakeDeployment_sinkinargs(t *testing.T) {
 		}},
 		ServiceAccountName: "test-service-account",
 		SinkInArgs:         true,
-		Labels:             map[string]string{"source": "test-name"},
+		Labels:             map[string]string{"eventing.knative.dev/source": "test-name"},
 		Annotations:        map[string]string{"sidecar.istio.io/inject": "true"},
 	})
 
@@ -225,7 +240,7 @@ func TestMakeDeployment_sinkinargs(t *testing.T) {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"source": "test-name",
+					"eventing.knative.dev/source": "test-name",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -234,7 +249,7 @@ func TestMakeDeployment_sinkinargs(t *testing.T) {
 						"sidecar.istio.io/inject": "true",
 					},
 					Labels: map[string]string{
-						"source": "test-name",
+						"eventing.knative.dev/source": "test-name",
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
## Proposed Changes

  * If labels or annotations are specified on the containersource, propagate them to the podspecs. This allows us to do things like control Istio outbound ip ranges.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
If containersource has labels or annotations, propagate them to the podspecs of the reified containersource deployments.
Change label denoting source from: `source` to `eventing.knative.dev/source`
This label can not be overwritten, others will be.
```