### PR TITLE
golang format tools

### DIFF
--- a/cmd/event_display/main.go
+++ b/cmd/event_display/main.go
@@ -21,11 +21,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	"github.com/knative/eventing-sources/pkg/kncloudevents"
-	"log"
-	"strings"
 )
 
 /*


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
