### PR TITLE
Change brokers references to bootstrap servers for Kafka event source

### DIFF
--- a/contrib/kafka/cmd/receive_adapter/main.go
+++ b/contrib/kafka/cmd/receive_adapter/main.go
@@ -33,14 +33,14 @@ import (
 )
 
 const (
-	envBrokers         = "KAFKA_BROKERS"
-	envTopics          = "KAFKA_TOPICS"
-	envConsumerGroup   = "KAFKA_CONSUMER_GROUP"
-	envNetSASLEnable   = "KAFKA_NET_SASL_ENABLE"
-	envNetSASLUser     = "KAFKA_NET_SASL_USER"
-	envNetSASLPassword = "KAFKA_NET_SASL_PASSWORD"
-	envNetTLSEnable    = "KAFKA_NET_TLS_ENABLE"
-	envSinkURI         = "SINK_URI"
+	envBootstrapServers = "KAFKA_BOOTSTRAP_SERVERS"
+	envTopics           = "KAFKA_TOPICS"
+	envConsumerGroup    = "KAFKA_CONSUMER_GROUP"
+	envNetSASLEnable    = "KAFKA_NET_SASL_ENABLE"
+	envNetSASLUser      = "KAFKA_NET_SASL_USER"
+	envNetSASLPassword  = "KAFKA_NET_SASL_PASSWORD"
+	envNetTLSEnable     = "KAFKA_NET_TLS_ENABLE"
+	envSinkURI          = "SINK_URI"
 )
 
 func getRequiredEnv(key string) string {
@@ -76,10 +76,10 @@ func main() {
 	}
 
 	adapter := &kafka.Adapter{
-		Brokers:       getRequiredEnv(envBrokers),
-		Topics:        getRequiredEnv(envTopics),
-		ConsumerGroup: getRequiredEnv(envConsumerGroup),
-		SinkURI:       getRequiredEnv(envSinkURI),
+		BootstrapServers: getRequiredEnv(envBootstrapServers),
+		Topics:           getRequiredEnv(envTopics),
+		ConsumerGroup:    getRequiredEnv(envConsumerGroup),
+		SinkURI:          getRequiredEnv(envSinkURI),
 		Net: kafka.AdapterNet{
 			SASL: kafka.AdapterSASL{
 				Enable:   getOptionalBoolEnv(envNetSASLEnable),

--- a/contrib/kafka/config/300-kafkasource.yaml
+++ b/contrib/kafka/config/300-kafkasource.yaml
@@ -42,7 +42,7 @@ spec:
           type: object
         spec:
           properties:
-            brokers:
+            bootstrapServers:
               type: string
             topics:
               type: string

--- a/contrib/kafka/pkg/adapter/adapter.go
+++ b/contrib/kafka/pkg/adapter/adapter.go
@@ -50,12 +50,12 @@ type AdapterNet struct {
 }
 
 type Adapter struct {
-	Brokers       string
-	Topics        string
-	ConsumerGroup string
-	Net           AdapterNet
-	SinkURI       string
-	client        client.Client
+	BootstrapServers string
+	Topics           string
+	ConsumerGroup    string
+	Net              AdapterNet
+	SinkURI          string
+	client           client.Client
 }
 
 // --------------------------------------------------------------------
@@ -101,7 +101,7 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 	kafkaConfig.Net.TLS.Enable = a.Net.TLS.Enable
 
 	// Start with a client
-	client, err := sarama.NewClient(strings.Split(a.Brokers, ","), kafkaConfig)
+	client, err := sarama.NewClient(strings.Split(a.BootstrapServers, ","), kafkaConfig)
 	if err != nil {
 		panic(err)
 	}
@@ -124,9 +124,8 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 	// Handle session
 	go func() {
 		for {
-			cerr := group.Consume(ctx, strings.Split(a.Topics, ","), a)
-			if cerr != nil {
-				panic(cerr)
+			if err := group.Consume(ctx, strings.Split(a.Topics, ","), a); err != nil {
+				panic(err)
 			}
 		}
 	}()

--- a/contrib/kafka/pkg/adapter/adapter_test.go
+++ b/contrib/kafka/pkg/adapter/adapter_test.go
@@ -57,10 +57,10 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 			defer sinkServer.Close()
 
 			a := &Adapter{
-				Topics:        "topic1,topic2",
-				Brokers:       "broker1,broker2",
-				ConsumerGroup: "group",
-				SinkURI:       sinkServer.URL,
+				Topics:           "topic1,topic2",
+				BootstrapServers: "server1,server2",
+				ConsumerGroup:    "group",
+				SinkURI:          sinkServer.URL,
 				client: func() client.Client {
 					c, _ := kncloudevents.NewDefaultClient(sinkServer.URL)
 					return c

--- a/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go
+++ b/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go
@@ -66,9 +66,9 @@ type KafkaSourceNetSpec struct {
 
 // KafkaSourceSpec defines the desired state of the KafkaSource.
 type KafkaSourceSpec struct {
-	// Brokers are the Kafka servers the consumer will connect to.
+	// Bootstrap servers are the Kafka servers the consumer will connect to.
 	// +required
-	Brokers string `json:"brokers"`
+	BootstrapServers string `json:"bootstrapServers"`
 
 	// Topic topics to consume messages from
 	// +required

--- a/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_validation_test.go
+++ b/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_validation_test.go
@@ -24,9 +24,9 @@ import (
 
 var (
 	fullSpec = KafkaSourceSpec{
-		Brokers:       "brokers",
-		Topics:        "topic",
-		ConsumerGroup: "group",
+		BootstrapServers: "servers",
+		Topics:           "topics",
+		ConsumerGroup:    "group",
 		Sink: &corev1.ObjectReference{
 			APIVersion: "foo",
 			Kind:       "bar",
@@ -56,10 +56,10 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 			},
 			allowed: false,
 		},
-		"Brokers changed": {
+		"Bootstrap servers changed": {
 			orig: &fullSpec,
 			updated: KafkaSourceSpec{
-				Topics:             "broker1,broker2",
+				BootstrapServers:   "server1,server2",
 				Sink:               fullSpec.Sink,
 				ServiceAccountName: fullSpec.ServiceAccountName,
 			},

--- a/contrib/kafka/pkg/reconciler/kafkasource_test.go
+++ b/contrib/kafka/pkg/reconciler/kafkasource_test.go
@@ -209,9 +209,9 @@ func getSource() *sourcesv1alpha1.KafkaSource {
 		},
 		ObjectMeta: om(testNS, sourceName),
 		Spec: sourcesv1alpha1.KafkaSourceSpec{
-			Brokers:       "broker1,broker2",
-			Topics:        "topic1,topic2",
-			ConsumerGroup: "group",
+			BootstrapServers: "server1,server2",
+			Topics:           "topic1,topic2",
+			ConsumerGroup:    "group",
 			Sink: &corev1.ObjectReference{
 				Name:       addressableName,
 				Kind:       addressableKind,

--- a/contrib/kafka/pkg/reconciler/resources/receive_adapter.go
+++ b/contrib/kafka/pkg/reconciler/resources/receive_adapter.go
@@ -61,8 +61,8 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 							ImagePullPolicy: "Always",
 							Env: []corev1.EnvVar{
 								{
-									Name:  "KAFKA_BROKERS",
-									Value: args.Source.Spec.Brokers,
+									Name:  "KAFKA_BOOTSTRAP_SERVERS",
+									Value: args.Source.Spec.BootstrapServers,
 								},
 								{
 									Name:  "KAFKA_TOPICS",

--- a/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
+++ b/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
@@ -34,7 +34,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 		Spec: v1alpha1.KafkaSourceSpec{
 			ServiceAccountName: "source-svc-acct",
 			Topics:             "topic1,topic2",
-			Brokers:            "broker1,broker2",
+			BootstrapServers:   "server1,server2",
 			ConsumerGroup:      "group",
 			Net: v1alpha1.KafkaSourceNetSpec{
 				SASL: v1alpha1.KafkaSourceSASLSpec{
@@ -96,8 +96,8 @@ func TestMakeReceiveAdapter(t *testing.T) {
 							ImagePullPolicy: "Always",
 							Env: []corev1.EnvVar{
 								{
-									Name:  "KAFKA_BROKERS",
-									Value: "broker1,broker2",
+									Name:  "KAFKA_BOOTSTRAP_SERVERS",
+									Value: "server1,server2",
 								},
 								{
 									Name:  "KAFKA_TOPICS",

--- a/contrib/kafka/samples/README.md
+++ b/contrib/kafka/samples/README.md
@@ -8,7 +8,7 @@ This sample demonstrates how to configure, deploy, and use the Apache Kafka Even
 ### Prerequisites
 1. An existing instance of Apache Kafka must be running to use the Apache Kafka Event Source.
     - In order to consume and produce messages, a topic must be created on the Apache Kafka instance.
-    - A list of brokers corresponding to Apache Kafka instance must be obtained.
+    - A list of bootstrap servers corresponding to Apache Kafka instance must be obtained.
 2. Install the `ko` CLI for building and deploying purposes.
     ```
     go get github.com/google/go-containerregistry/cmd/ko
@@ -51,7 +51,7 @@ The following steps build and deploy the Apache Kafka Event Controller, Source, 
     ```
 
 #### Apache Kafka Event Source
-1. Modify `contrib/kafka/samples/event-source.yaml` accordingly with brokers, topic, etc... 
+1. Modify `contrib/kafka/samples/event-source.yaml` accordingly with bootstrap servers, topics, etc... 
 2. Build and deploy the event source.
     ```
     $ ko apply -f contrib/kafka/samples/event-source.yaml
@@ -67,7 +67,7 @@ The following steps build and deploy the Apache Kafka Event Controller, Source, 
 4.  Ensure the Apache Kafka Event Source started with the necessary configuration.
     ```
     $ kubectl logs kafka-source-xlnhq-5544766765-dnl5s
-    {"level":"info","ts":"2019-03-19T22:31:52.689Z","caller":"receive_adapter/main.go:97","msg":"Starting Apache Kafka Receive Adapter...","adapter":{"Brokers":"...","Topic":"...","ConsumerGroup":"...","Net":{"SASL":{"Enable":true,"User":"...","Password":"..."},"TLS":{"Enable":true}},"SinkURI":"http://event-display.default.svc.cluster.local/"}}
+    {"level":"info","ts":"2019-03-19T22:31:52.689Z","caller":"receive_adapter/main.go:97","msg":"Starting Apache Kafka Receive Adapter...","adapter":{"BootstrapServers":"...","Topic":"...","ConsumerGroup":"...","Net":{"SASL":{"Enable":true,"User":"...","Password":"..."},"TLS":{"Enable":true}},"SinkURI":"http://event-display.default.svc.cluster.local/"}}
     ```
 
 #### Event Display 

--- a/contrib/kafka/samples/event-source.yaml
+++ b/contrib/kafka/samples/event-source.yaml
@@ -14,7 +14,7 @@
 
 # Replace the following before applying this file:
 #   KAFKA_CONSUMER_GROUP_NAME: Name of Kafka consumer group
-#   KAFKA_BROKERS: Comma-separated list of brokers
+#   KAFKA_BOOTSTRAP_SERVERS: Comma-separated list of bootstrap servers
 #   KAFKA_TOPICS: Comma-separated list of topics
 #   KAFKA_SASL_ENABLE: Truthy value to enable/disable SASL, disabled by default (optional)
 #   KAFKA_SASL_USERNAME: Username for SASL authentication (optional)
@@ -27,7 +27,7 @@ metadata:
   name: kafka-source
 spec:
   consumerGroup: KAFKA_CONSUMER_GROUP_NAME
-  brokers: KAFKA_BROKERS
+  bootstrapServers: KAFKA_BOOTSTRAP_SERVERS
   topics: KAFKA_TOPICS
   net:
     sasl:


### PR DESCRIPTION
Replaces references to `brokers` with `bootstrap servers` for consistency with Apache Kafka documentation.