### PR TITLE
golang format tools

### DIFF
--- a/contrib/kafka/cmd/controller/main.go
+++ b/contrib/kafka/cmd/controller/main.go
@@ -17,10 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"log"
+
 	"github.com/knative/eventing-sources/contrib/kafka/pkg/apis"
 	controller "github.com/knative/eventing-sources/contrib/kafka/pkg/reconciler"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"log"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"

--- a/contrib/kafka/pkg/adapter/adapter.go
+++ b/contrib/kafka/pkg/adapter/adapter.go
@@ -18,6 +18,9 @@ package kafka
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
+
 	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
@@ -26,8 +29,6 @@ import (
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
-	"strconv"
-	"strings"
 )
 
 const (

--- a/contrib/kafka/pkg/adapter/adapter_test.go
+++ b/contrib/kafka/pkg/adapter/adapter_test.go
@@ -19,14 +19,15 @@ package kafka
 import (
 	"context"
 	"encoding/json"
-	"github.com/Shopify/sarama"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	"github.com/knative/eventing-sources/pkg/kncloudevents"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
+	"github.com/knative/eventing-sources/pkg/kncloudevents"
 )
 
 func TestPostMessage_ServeHTTP(t *testing.T) {

--- a/contrib/kafka/pkg/apis/sources/v1alpha1/register_test.go
+++ b/contrib/kafka/pkg/apis/sources/v1alpha1/register_test.go
@@ -16,9 +16,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"testing"
 )
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource

--- a/contrib/kafka/pkg/reconciler/kafkasource.go
+++ b/contrib/kafka/pkg/reconciler/kafkasource.go
@@ -34,7 +34,7 @@ import (
 	"github.com/knative/eventing-sources/contrib/kafka/pkg/apis/sources/v1alpha1"
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/contrib/kafka/pkg/reconciler/kafkasource_test.go
+++ b/contrib/kafka/pkg/reconciler/kafkasource_test.go
@@ -26,7 +26,7 @@ import (
 	genericv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	controllertesting "github.com/knative/eventing-sources/pkg/controller/testing"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/contrib/kafka/pkg/reconciler/resources/receive_adapter.go
+++ b/contrib/kafka/pkg/reconciler/resources/receive_adapter.go
@@ -18,11 +18,12 @@ package resources
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/knative/eventing-sources/contrib/kafka/pkg/apis/sources/v1alpha1"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 type ReceiveAdapterArgs struct {

--- a/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
+++ b/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package resources
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/eventing-sources/contrib/kafka/pkg/apis/sources/v1alpha1"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestMakeReceiveAdapter(t *testing.T) {


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
