### PR TITLE
Update Kafka consumer group error message

### DIFF
--- a/contrib/kafka/pkg/adapter/adapter.go
+++ b/contrib/kafka/pkg/adapter/adapter.go
@@ -118,7 +118,7 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 	// Track errors
 	go func() {
 		for err := range group.Errors() {
-			logger.Error("ERROR", err)
+			logger.Error("A consumer group error occurred: ", zap.Error(err))
 		}
 	}()
 


### PR DESCRIPTION
Modifying the consumer group error message format. Currently when a consumer group error occurs, the error message looks slightly malformed as shown below.

```
{"level":"error","ts":1553634511.7164414,"logger":"fallback","caller":"adapter/adapter.go:120","msg":"ERRORkafka: error while consuming dubee2/0: read tcp 172.30.43.26:48366->23.246.202.59:9093: read: connection reset by peer","stacktrace":"github.com/knative/eventing-sources/contrib/kafka/pkg/adapter.(*Adapter).Start.func3\n\t/Users/jwdubee/go/src/github.com/knative/eventing-sources/contrib/kafka/pkg/adapter/adapter.go:120"}
```