### PR TITLE
Rename release artifacts to eventing-sources.yaml

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -19,7 +19,7 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["release.yaml"]="config"
+  ["eventing-sources.yaml"]="config"
   ["gcppubsub.yaml"]="contrib/gcppubsub/config"
   ["event-display.yaml"]="config/tools/event-display"
   ["camel.yaml"]="contrib/camel/config"

--- a/samples/awssqs_source/README.md
+++ b/samples/awssqs_source/README.md
@@ -10,7 +10,7 @@
 1.  If your installed version of Eventing did not include the in-memory channel
     provisioner, install the
     [in-memory `ClusterChannelProvisioner`](https://github.com/knative/eventing/tree/master/config/provisioners/in-memory-channel)
-    now. If you installed Eventing using the `release.yaml` file, the channel
+    now. If you installed Eventing using the `eventing.yaml` file, the channel
     provisioner was included. (See the
     [Custom install guide](https://www.knative.dev/docs/install/knative-custom-install/)
     for information about what is include in each install file.)

--- a/samples/cronjob-source/README.md
+++ b/samples/cronjob-source/README.md
@@ -8,7 +8,7 @@
 1. If your installed version of Eventing did not include the in-memory channel
    provisioner, install the
    [in-memory `ClusterChannelProvisioner`](https://github.com/knative/eventing/tree/master/config/provisioners/in-memory-channel)
-   now. If you installed Eventing using the `release.yaml` file, the channel
+   now. If you installed Eventing using the `eventing.yaml` file, the channel
    provisioner was included. (See the
    [Custom install guide](https://www.knative.dev/docs/install/knative-custom-install/)
    for information about what is include in each install file.)


### PR DESCRIPTION
It was still `release.yaml`, but all others were like `build.yaml`, `serving.yaml` or `eventing.yaml`

+ update doc that were pointing to "old" `release.yaml` from eventing (not eventing-sources)