### PR TITLE
KafkaSource missing RBAC rule for finalizers

### DIFF
--- a/contrib/kafka/config/201-clusterrole.yaml
+++ b/contrib/kafka/config/201-clusterrole.yaml
@@ -22,6 +22,7 @@ rules:
   - sources.eventing.knative.dev
   resources:
   - kafkasources
+  - kafkasources/finalizers
   - services
   verbs: &everything
   - get


### PR DESCRIPTION
At least on OpenShift, which has fairly restrictive RBAC out of the
box, KafkaSource is missing a rule needed for its call to
`controllerutil.SetControllerReference(src, svc, r.scheme)` that
requires permissions on the `kafkasource/finalizers` resource.
