### PR TITLE
Add a label knative.dev/crd-install to CRDs to allow installing CRDs in a separate pass.

### DIFF
--- a/config/300-awssqssource.yaml
+++ b/config/300-awssqssource.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
   name: awssqssources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/config/300-containersource.yaml
+++ b/config/300-containersource.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
   name: containersources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/config/300-cronjobsource.yaml
+++ b/config/300-cronjobsource.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
   name: cronjobsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/config/300-githubsource.yaml
+++ b/config/300-githubsource.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
   name: githubsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/config/300-kuberneteseventsource.yaml
+++ b/config/300-kuberneteseventsource.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
   name: kuberneteseventsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/contrib/camel/config/300-camelsource.yaml
+++ b/contrib/camel/config/300-camelsource.yaml
@@ -18,6 +18,7 @@ metadata:
   creationTimestamp: null
   labels:
     eventing.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
   name: camelsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/contrib/gcppubsub/config/300-gcppubsubsource.yaml
+++ b/contrib/gcppubsub/config/300-gcppubsubsource.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
   name: gcppubsubsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev

--- a/contrib/kafka/config/300-kafkasource.yaml
+++ b/contrib/kafka/config/300-kafkasource.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     eventing.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
   name: kafkasources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev


### PR DESCRIPTION
## Proposed Changes

- Label CRDs so that they can be installed first with `kubectl -l knative.dev/crd-install=true YAML_FILE`

**Release Note**

```release-note
- CRDs are now labelled with knative.dev/crd-install=true to allow installing without race conditions or kubectl errors.
```