### PR TITLE
Add a ConcurrencyPerPartition option to KafkaSource

### DIFF
--- a/contrib/kafka/cmd/receive_adapter/main.go
+++ b/contrib/kafka/cmd/receive_adapter/main.go
@@ -33,14 +33,15 @@ import (
 )
 
 const (
-	envBootstrapServers = "KAFKA_BOOTSTRAP_SERVERS"
-	envTopics           = "KAFKA_TOPICS"
-	envConsumerGroup    = "KAFKA_CONSUMER_GROUP"
-	envNetSASLEnable    = "KAFKA_NET_SASL_ENABLE"
-	envNetSASLUser      = "KAFKA_NET_SASL_USER"
-	envNetSASLPassword  = "KAFKA_NET_SASL_PASSWORD"
-	envNetTLSEnable     = "KAFKA_NET_TLS_ENABLE"
-	envSinkURI          = "SINK_URI"
+	envBootstrapServers        = "KAFKA_BOOTSTRAP_SERVERS"
+	envTopics                  = "KAFKA_TOPICS"
+	envConsumerGroup           = "KAFKA_CONSUMER_GROUP"
+	envNetSASLEnable           = "KAFKA_NET_SASL_ENABLE"
+	envNetSASLUser             = "KAFKA_NET_SASL_USER"
+	envNetSASLPassword         = "KAFKA_NET_SASL_PASSWORD"
+	envNetTLSEnable            = "KAFKA_NET_TLS_ENABLE"
+	envConcurrencyPerPartition = "CONCURRENCY_PER_PARTITION"
+	envSinkURI                 = "SINK_URI"
 )
 
 func getRequiredEnv(key string) string {
@@ -49,6 +50,15 @@ func getRequiredEnv(key string) string {
 		log.Fatalf("Required environment variable not defined for key '%s'.", key)
 	}
 
+	return val
+}
+
+func getRequiredIntEnv(key string) int {
+	stringVal := getRequiredEnv(key)
+	val, err := strconv.Atoi(stringVal)
+	if err != nil {
+		log.Fatalf("Required environment variable '%s' was not an int.", key)
+	}
 	return val
 }
 
@@ -76,10 +86,11 @@ func main() {
 	}
 
 	adapter := &kafka.Adapter{
-		BootstrapServers: getRequiredEnv(envBootstrapServers),
-		Topics:           getRequiredEnv(envTopics),
-		ConsumerGroup:    getRequiredEnv(envConsumerGroup),
-		SinkURI:          getRequiredEnv(envSinkURI),
+		BootstrapServers:        getRequiredEnv(envBootstrapServers),
+		Topics:                  getRequiredEnv(envTopics),
+		ConsumerGroup:           getRequiredEnv(envConsumerGroup),
+		ConcurrencyPerPartition: getRequiredIntEnv(envConcurrencyPerPartition),
+		SinkURI:                 getRequiredEnv(envSinkURI),
 		Net: kafka.AdapterNet{
 			SASL: kafka.AdapterSASL{
 				Enable:   getOptionalBoolEnv(envNetSASLEnable),

--- a/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go
+++ b/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go
@@ -78,6 +78,12 @@ type KafkaSourceSpec struct {
 	// +required
 	ConsumerGroup string `json:"consumerGroup"`
 
+	// ConcurrencyPerPartition is the maximum concurrency to use when
+	// processing messages from a single partition. A value of 0 (the
+	// default) means unbounded.
+	// +optional
+	ConcurrencyPerPartition int `json:"concurrencyPerPartition"`
+
 	Net KafkaSourceNetSpec `json:"net,omitempty"`
 
 	// Sink is a reference to an object that will resolve to a domain name to use as the sink.

--- a/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_validation_test.go
+++ b/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_validation_test.go
@@ -24,9 +24,10 @@ import (
 
 var (
 	fullSpec = KafkaSourceSpec{
-		BootstrapServers: "servers",
-		Topics:           "topics",
-		ConsumerGroup:    "group",
+		BootstrapServers:        "servers",
+		Topics:                  "topics",
+		ConsumerGroup:           "group",
+		ConcurrencyPerPartition: 50,
 		Sink: &corev1.ObjectReference{
 			APIVersion: "foo",
 			Kind:       "bar",
@@ -131,6 +132,15 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 					Namespace:  fullSpec.Sink.Namespace,
 					Name:       "some-other-name",
 				},
+				ServiceAccountName: fullSpec.ServiceAccountName,
+			},
+			allowed: false,
+		},
+		"ConcurrencyPerPartition changed": {
+			orig: &fullSpec,
+			updated: KafkaSourceSpec{
+				ConcurrencyPerPartition: 1,
+				Sink:               fullSpec.Sink,
 				ServiceAccountName: fullSpec.ServiceAccountName,
 			},
 			allowed: false,

--- a/contrib/kafka/pkg/reconciler/resources/receive_adapter.go
+++ b/contrib/kafka/pkg/reconciler/resources/receive_adapter.go
@@ -90,6 +90,10 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 									Value: strconv.FormatBool(args.Source.Spec.Net.TLS.Enable),
 								},
 								{
+									Name:  "CONCURRENCY_PER_PARTITION",
+									Value: strconv.Itoa(args.Source.Spec.ConcurrencyPerPartition),
+								},
+								{
 									Name:  "SINK_URI",
 									Value: args.SinkURI,
 								},

--- a/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
+++ b/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
@@ -33,10 +33,11 @@ func TestMakeReceiveAdapter(t *testing.T) {
 			Namespace: "source-namespace",
 		},
 		Spec: v1alpha1.KafkaSourceSpec{
-			ServiceAccountName: "source-svc-acct",
-			Topics:             "topic1,topic2",
-			BootstrapServers:   "server1,server2",
-			ConsumerGroup:      "group",
+			ServiceAccountName:      "source-svc-acct",
+			Topics:                  "topic1,topic2",
+			BootstrapServers:        "server1,server2",
+			ConsumerGroup:           "group",
+			ConcurrencyPerPartition: 5,
 			Net: v1alpha1.KafkaSourceNetSpec{
 				SASL: v1alpha1.KafkaSourceSASLSpec{
 					Enable:   true,
@@ -123,6 +124,10 @@ func TestMakeReceiveAdapter(t *testing.T) {
 								{
 									Name:  "KAFKA_NET_TLS_ENABLE",
 									Value: "true",
+								},
+								{
+									Name:  "CONCURRENCY_PER_PARTITION",
+									Value: "5",
 								},
 								{
 									Name:  "SINK_URI",


### PR DESCRIPTION
Fixes #320

## Proposed Changes

  * Add a spec.concurrencyPerPartition field to the KafkaSource CRD.

Copied from the 1st commit in this PR:

This field, if set, will limit that maximum number of concurrent sends (ie POSTS) of CloudEvent messages at a time for each partition. If left unset or set to 0, which is the default, the concurrency is unbounded.

When processing a large number of messages from a Kafka topic, the unbounded behavior leads to massive numbers of goroutines being created. This leads to problems with too many open sockets attempting to all POST to the sink at the same time.

So, in practice, we may want to actually default this to a reasonably high value that allows for a high throughput per topic partition without blowing up if processing a huge backlog of messages on a topic.

Note that, as the name implies, this bounds concurrency per partition. If a topic has many partitions and only a single receive adapter pod running (the default today) then you'll have up to `ConcurrencyPerPartition * numPartitions` concurrent HTTP POSTS to the sink.