### PR TITLE
Removing inner claim goroutine

### DIFF
--- a/contrib/kafka/pkg/adapter/adapter.go
+++ b/contrib/kafka/pkg/adapter/adapter.go
@@ -79,15 +79,13 @@ func (a *Adapter) ConsumeClaim(sess sarama.ConsumerGroupSession, claim sarama.Co
 	for msg := range claim.Messages() {
 		logger.Info("Received: ", zap.Any("value", string(msg.Value)))
 
-		go func(msg *sarama.ConsumerMessage) {
-			// send and mark message if post was successful
-			if err := a.postMessage(context.TODO(), msg); err == nil {
-				sess.MarkMessage(msg, "")
-				logger.Debug("Successfully sent event to sink")
-			} else {
-				logger.Error("Sending event to sink failed: ", zap.Error(err))
-			}
-		}(msg)
+		// send and mark message if post was successful
+		if err := a.postMessage(context.TODO(), msg); err == nil {
+			sess.MarkMessage(msg, "")
+			logger.Debug("Successfully sent event to sink")
+		} else {
+			logger.Error("Sending event to sink failed: ", zap.Error(err))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
based on slack chats of @bbrowning and @markfisher I am removing the inner Claim `goroutine`. Matching the Sarama "best practises", by the documentation:
https://github.com/Shopify/sarama/blob/master/examples/consumergroup/main.go#L124

From the Sarama doc:
```
	// 3. For each of the assigned claims the handler's ConsumeClaim() function is then called
	//    in a separate goroutine which requires it to be thread-safe. Any state must be carefully protected
```
Perhaps we should add a comment in the code, to _not_ put a goroutine inside the `ConsumeClaim`?

Others might like to do the same failure, that I did: and overuse (or abuse) concurrency.
