### PR TITLE
Revert "Make upload test images simpler"

### DIFF
--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -16,19 +16,22 @@
 
 set -o errexit
 
-# TODO(https://github.com/knative/test-infra/issues/590): Create a common way of uploading images
 function upload_test_images() {
   echo ">> Publishing test images"
-  local image_dir="$(dirname $0)/test_images"
+  local image_dirs="$(find $(dirname $0)/test_images -mindepth 1 -maxdepth 1 -type d)"
   local docker_tag=$1
-  local tag_option=""
-  if [ -n "${docker_tag}" ]; then
-    tag_option="--tags $docker_tag,latest"
-  fi
 
-  # ko resolve is being used for the side-effect of publishing images,
-  # so the resulting yaml produced is ignored.
-  ko resolve ${tag_option} -RBf "${image_dir}" > /dev/null
+  for image_dir in ${image_dirs}; do
+      local image_name="$(basename ${image_dir})"
+      local image="github.com/knative/eventing-sources/test/test_images/${image_name}"
+      ko publish -B ${image}
+      if [ -n "$docker_tag" ]; then
+          image=$KO_DOCKER_REPO/${image_name}
+          local digest=$(gcloud container images list-tags --filter="tags:latest" --format='get(digest)' ${image})
+          echo "Tagging ${image}@${digest} with $docker_tag"
+          gcloud -q container images add-tag ${image}@${digest} ${image}:$docker_tag
+      fi
+  done
 }
 
 : ${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO', see DEVELOPMENT.md"}


### PR DESCRIPTION
Reverts knative/eventing-sources#263 which seems to be causing test images to not be uploaded.