### PR TITLE
contrib/kafka: use secrets for SASL user and password

### DIFF
--- a/contrib/kafka/config/300-kafkasource.yaml
+++ b/contrib/kafka/config/300-kafkasource.yaml
@@ -52,10 +52,37 @@ spec:
             consumerGroup:
               type: string
               minLength: 1
+            consumerGroup:
+              type: string
+            net:
+              properties:
+                sasl:
+                  properties:
+                    enable:
+                      type: boolean
+                    password:
+                      properties:
+                        secretKeyRef:
+                          type: object
+                      type: object
+                    user:
+                      properties:
+                        secretKeyRef:
+                          type: object
+                      type: object
+                  type: object
+                tls:
+                  properties:
+                    enable:
+                      type: boolean
+                  type: object
+              type: object
             serviceAccountName:
               type: string
             sink:
               type: object
+            topics:
+              type: string
           type: object
           required:
               - bootstrapServers
@@ -83,6 +110,9 @@ spec:
                 - status
                 type: object
               type: array
+            observedGeneration:
+              format: int64
+              type: integer
             sinkUri:
               type: string
           type: object

--- a/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go
+++ b/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	sourcesv1alpha1 "github.com/knative/eventing-sources/pkg/apis/sources/v1alpha1"
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
@@ -50,9 +51,14 @@ var _ apis.Immutable = (*KafkaSource)(nil)
 var _ = duck.VerifyType(&KafkaSource{}, &duckv1alpha1.Conditions{})
 
 type KafkaSourceSASLSpec struct {
-	Enable   bool   `json:"enable,omitempty"`
-	User     string `json:"user,omitempty"`
-	Password string `json:"password,omitempty"`
+	Enable bool `json:"enable,omitempty"`
+
+	// User is the Kubernetes secret containing the SASL username.
+	// +optional
+	User sourcesv1alpha1.SecretValueFromSource `json:"user,omitempty"`
+	// Password is the Kubernetes secret containing the SASL password.
+	// +optional
+	Password sourcesv1alpha1.SecretValueFromSource `json:"password,omitempty"`
 }
 
 type KafkaSourceTLSSpec struct {

--- a/contrib/kafka/samples/event-source.yaml
+++ b/contrib/kafka/samples/event-source.yaml
@@ -17,8 +17,10 @@
 #   KAFKA_BOOTSTRAP_SERVERS: Comma-separated list of bootstrap servers
 #   KAFKA_TOPICS: Comma-separated list of topics
 #   KAFKA_SASL_ENABLE: Truthy value to enable/disable SASL, disabled by default (optional)
-#   KAFKA_SASL_USERNAME: Username for SASL authentication (optional)
-#   KAFKA_SASL_PASSWORD: Password for SASL authentication (optional)
+#   KAFKA_SASL_USER_SECRET_NAME: Name of secret containing SASL user (optional)
+#   KAFKA_SASL_USER_SECRET_KEY: Key within secret containing SASL user (optional)
+#   KAFKA_SASL_PASSWORD_SECRET_NAME: Name of secret containing SASL password (optional)
+#   KAFKA_SASL_PASSWORD_SECRET_KEY: Key within secret containing SASL password (optional)
 #   KAFKA_TLS_ENABLE: Truthy to enable TLS, disabled by default (optional)
 
 apiVersion: sources.eventing.knative.dev/v1alpha1
@@ -32,8 +34,14 @@ spec:
   net:
     sasl:
       enable: KAFKA_SASL_ENABLE
-      user: KAFKA_SASL_USERNAME
-      password: KAFKA_SASL_PASSWORD
+      user:
+        secretKeyRef:
+          name: KAFKA_SASL_USER_SECRET_NAME
+          key: KAFKA_SASL_USER_SECRET_KEY
+      password:
+        secretKeyRef:
+          name: KAFKA_SASL_PASSWORD_SECRET_NAME
+          key: KAFKA_SASL_PASSWORD_SECRET_KEY
     tls:
       enable: KAFKA_TLS_ENABLE
   sink:


### PR DESCRIPTION
## Proposed Changes

Change the Kafka source spec to use SecretValueFromSource for user and
password, similar to the GitHub source.

This means the SASL user and password will no longer be stored in cleartext in the KafkaSource resources.

Based on #289 I did not allow for a graceful transition to this new scheme but happy to add it if needed.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
KafkaSource User and Password are now references to keys in secrets instead of plaintext values. Existing KafkaSource resources will need to be updated.
```