### PR TITLE
golang format tools

### DIFF
--- a/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_validation.go
+++ b/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
 )

--- a/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_validation.go
+++ b/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
 )


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
