### PR TITLE
Missing RBAC rules for finalizers

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -39,9 +39,19 @@ rules:
 - apiGroups:
   - sources.eventing.knative.dev
   resources:
-  - '*/finalizers'
-  verbs:
-  - '*'
+  - awssqssources/finalizers
+  - containersources/finalizers
+  - cronjobsources/finalizers
+  - githubsources/finalizers
+  - kuberneteseventsources/finalizers
+  verbs: &everything
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 
 # Source statuses update
 - apiGroups:

--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -44,14 +44,7 @@ rules:
   - cronjobsources/finalizers
   - githubsources/finalizers
   - kuberneteseventsources/finalizers
-  verbs: &everything
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  verbs: *everything
 
 # Source statuses update
 - apiGroups:

--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -35,6 +35,14 @@ rules:
   - patch
   - delete
 
+# Sources finalizer
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - '*/finalizers'
+  verbs:
+  - '*'
+
 # Source statuses update
 - apiGroups:
   - sources.eventing.knative.dev


### PR DESCRIPTION
At least on OpenShift, which has fairly restrictive RBAC out of the
box, the sources are missing a RBAC rules that
requires permissions on the different *sources/finalizers resource.

See also #318

/cc @evankanderson 