### PR TITLE
Update event-sources to not use fallback logger

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/knative/eventing-sources/pkg/apis"
 	_ "github.com/knative/eventing-sources/pkg/apis/serving/v1alpha1"
@@ -32,15 +31,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
-const (
-	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
-)
-
 func main() {
 	logCfg := zap.NewProductionConfig()
 	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logger, err := logCfg.Build()
-	logger = logger.With(zap.String(logkey.ControllerType, os.Getenv(ConfigMapNameEnv)))
+	logger = logger.With(zap.String(logkey.ControllerType, "controller-manager"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,17 +18,33 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/knative/eventing-sources/pkg/apis"
 	_ "github.com/knative/eventing-sources/pkg/apis/serving/v1alpha1"
 	"github.com/knative/eventing-sources/pkg/controller"
+	"github.com/knative/pkg/logging/logkey"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+const (
+	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
+)
+
 func main() {
+	logCfg := zap.NewProductionConfig()
+	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := logCfg.Build()
+	logger = logger.With(zap.String(logkey.ControllerType, os.Getenv(ConfigMapNameEnv)))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -49,7 +65,7 @@ func main() {
 	}
 
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
+	if err := controller.AddToManager(mgr, logger.Sugar()); err != nil {
 		log.Fatal(err)
 	}
 

--- a/contrib/camel/cmd/controller/main.go
+++ b/contrib/camel/cmd/controller/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/knative/eventing-sources/contrib/camel/pkg/apis"
 	"github.com/knative/eventing-sources/contrib/camel/pkg/reconciler"
@@ -30,16 +29,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
-const (
-	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
-)
-
 func main() {
 	// Get a config to talk to the apiserver
 	logCfg := zap.NewProductionConfig()
 	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logger, err := logCfg.Build()
-	logger = logger.With(zap.String(logkey.ControllerType, os.Getenv(ConfigMapNameEnv)))
+	logger = logger.With(zap.String(logkey.ControllerType, "camel-controller"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/contrib/camel/cmd/controller/main.go
+++ b/contrib/camel/cmd/controller/main.go
@@ -18,16 +18,32 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/knative/eventing-sources/contrib/camel/pkg/apis"
 	"github.com/knative/eventing-sources/contrib/camel/pkg/reconciler"
+	"github.com/knative/pkg/logging/logkey"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+const (
+	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
+)
+
 func main() {
 	// Get a config to talk to the apiserver
+	logCfg := zap.NewProductionConfig()
+	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := logCfg.Build()
+	logger = logger.With(zap.String(logkey.ControllerType, os.Getenv(ConfigMapNameEnv)))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	cfg, err := config.GetConfig()
 	if err != nil {
 		log.Fatal(err)
@@ -49,7 +65,7 @@ func main() {
 	log.Printf("Setting up Controllers.")
 
 	// Setup all Controllers
-	if err := reconciler.Add(mgr); err != nil {
+	if err := reconciler.Add(mgr, logger.Sugar()); err != nil {
 		log.Fatal(err)
 	}
 

--- a/contrib/camel/pkg/reconciler/camelsource.go
+++ b/contrib/camel/pkg/reconciler/camelsource.go
@@ -49,7 +49,7 @@ const (
 // Add creates a new CamelSource Controller and adds it to the Manager with
 // default RBAC. The Manager will set fields on the Controller and Start it when
 // the Manager is Started.
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 	log.Println("Adding the Camel Source controller.")
 
 	// Register Camel specific types
@@ -68,7 +68,7 @@ func Add(mgr manager.Manager) error {
 		},
 	}
 
-	return p.Add(mgr)
+	return p.Add(mgr, logger)
 }
 
 type reconciler struct {

--- a/contrib/gcppubsub/cmd/controller/main.go
+++ b/contrib/gcppubsub/cmd/controller/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/knative/eventing-sources/contrib/gcppubsub/pkg/apis"
 	controller "github.com/knative/eventing-sources/contrib/gcppubsub/pkg/reconciler"
@@ -31,15 +30,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
-const (
-	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
-)
-
 func main() {
 	logCfg := zap.NewProductionConfig()
 	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logger, err := logCfg.Build()
-	logger = logger.With(zap.String(logkey.ControllerType, os.Getenv(ConfigMapNameEnv)))
+	logger = logger.With(zap.String(logkey.ControllerType, "gcppubsub-controller"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/contrib/gcppubsub/cmd/controller/main.go
+++ b/contrib/gcppubsub/cmd/controller/main.go
@@ -18,16 +18,32 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/knative/eventing-sources/contrib/gcppubsub/pkg/apis"
 	controller "github.com/knative/eventing-sources/contrib/gcppubsub/pkg/reconciler"
+	"github.com/knative/pkg/logging/logkey"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+const (
+	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
+)
+
 func main() {
+	logCfg := zap.NewProductionConfig()
+	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := logCfg.Build()
+	logger = logger.With(zap.String(logkey.ControllerType, os.Getenv(ConfigMapNameEnv)))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -48,7 +64,7 @@ func main() {
 	}
 
 	// Setup pubsub Controller
-	if err := controller.Add(mgr); err != nil {
+	if err := controller.Add(mgr, logger.Sugar()); err != nil {
 		log.Fatal(err)
 	}
 

--- a/contrib/gcppubsub/pkg/reconciler/gcppubsubsource.go
+++ b/contrib/gcppubsub/pkg/reconciler/gcppubsubsource.go
@@ -60,7 +60,7 @@ const (
 // Add creates a new GcpPubSubSource Controller and adds it to the Manager with
 // default RBAC. The Manager will set fields on the Controller and Start it when
 // the Manager is Started.
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 	raImage, defined := os.LookupEnv(raImageEnvVar)
 	if !defined {
 		return fmt.Errorf("required environment variable '%s' not defined", raImageEnvVar)
@@ -78,7 +78,7 @@ func Add(mgr manager.Manager) error {
 		},
 	}
 
-	return p.Add(mgr)
+	return p.Add(mgr, logger)
 }
 
 // gcpPubSubClientCreator creates a real GCP PubSub client. It should always be used, except during

--- a/contrib/kafka/cmd/controller/main.go
+++ b/contrib/kafka/cmd/controller/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/knative/eventing-sources/contrib/kafka/pkg/apis"
 	controller "github.com/knative/eventing-sources/contrib/kafka/pkg/reconciler"
@@ -31,16 +30,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
-const (
-	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
-)
-
 func main() {
 	// Get a config to talk to the API server
 	logCfg := zap.NewProductionConfig()
 	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logger, err := logCfg.Build()
-	logger = logger.With(zap.String(logkey.ControllerType, os.Getenv(ConfigMapNameEnv)))
+	logger = logger.With(zap.String(logkey.ControllerType, "kafka-controller"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/contrib/kafka/cmd/controller/main.go
+++ b/contrib/kafka/cmd/controller/main.go
@@ -18,17 +18,33 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/knative/eventing-sources/contrib/kafka/pkg/apis"
 	controller "github.com/knative/eventing-sources/contrib/kafka/pkg/reconciler"
+	"github.com/knative/pkg/logging/logkey"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+const (
+	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
+)
+
 func main() {
 	// Get a config to talk to the API server
+	logCfg := zap.NewProductionConfig()
+	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := logCfg.Build()
+	logger = logger.With(zap.String(logkey.ControllerType, os.Getenv(ConfigMapNameEnv)))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	cfg, err := config.GetConfig()
 	if err != nil {
 		log.Fatal(err)
@@ -50,7 +66,7 @@ func main() {
 	log.Printf("Setting up Controller.")
 
 	// Setup Kafka Controller
-	if err := controller.Add(mgr); err != nil {
+	if err := controller.Add(mgr, logger.Sugar()); err != nil {
 		log.Fatal(err)
 	}
 

--- a/contrib/kafka/cmd/receive_adapter/main.go
+++ b/contrib/kafka/cmd/receive_adapter/main.go
@@ -29,6 +29,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/signals"
 )
 
@@ -71,6 +72,8 @@ func main() {
 	logCfg := zap.NewProductionConfig()
 	logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logger, err := logCfg.Build()
+	ctx = logging.WithLogger(ctx, logger.Sugar())
+
 	if err != nil {
 		log.Fatalf("Unable to create logger: %v", err)
 	}

--- a/contrib/kafka/pkg/adapter/adapter.go
+++ b/contrib/kafka/pkg/adapter/adapter.go
@@ -97,7 +97,12 @@ func (a *Adapter) ConsumeClaim(sess sarama.ConsumerGroupSession, claim sarama.Co
 func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 	logger := logging.FromContext(ctx)
 
-	logger.Info("Starting with config: ", zap.Any("adapter", a))
+	logger.Infow("Starting with config: ",
+		zap.String("bootstrap_server", a.BootstrapServers),
+		zap.String("Topics", a.Topics),
+		zap.String("ConsumerGroup", a.ConsumerGroup),
+		zap.String("SinkURI", a.SinkURI),
+		zap.Bool("TLS", a.Net.SASL.Enable))
 
 	kafkaConfig := sarama.NewConfig()
 	kafkaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
@@ -141,7 +146,7 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 	for {
 		select {
 		case <-stopCh:
-			logger.Info("Shutting down...")
+			logger.Infow("Shutting down...")
 			return nil
 		}
 	}

--- a/contrib/kafka/pkg/reconciler/kafkasource.go
+++ b/contrib/kafka/pkg/reconciler/kafkasource.go
@@ -48,7 +48,7 @@ const (
 	raImageEnvVar       = "KAFKA_RA_IMAGE"
 )
 
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 	raImage, defined := os.LookupEnv(raImageEnvVar)
 	if !defined {
 		return fmt.Errorf("required environment variable '%s' not defined", raImageEnvVar)
@@ -65,7 +65,7 @@ func Add(mgr manager.Manager) error {
 		},
 	}
 
-	return p.Add(mgr)
+	return p.Add(mgr, logger)
 }
 
 type reconciler struct {

--- a/contrib/kafka/samples/README.md
+++ b/contrib/kafka/samples/README.md
@@ -179,12 +179,15 @@ and an Event Display Service.
    ```
 2. Check that the Apache Kafka Event Source consumed the message and sent it to
    its sink properly.
+
    ```
    $ kubectl logs kafka-source-xlnhq-5544766765-dnl5s
    ...
-   {"level":"info","ts":1554145778.9344022,"logger":"fallback","caller":"adapter/adapter.go:80","msg":"Received: {topic: 15 0 ... <nil>} {partition: 11 2  <nil>} {offset: 11 0  <nil>}"}
-   {"level":"info","ts":1553034726.546107,"logger":"fallback","caller":"adapter/adapter.go:154","msg":"Successfully sent event to sink"}
+   {"level":"info","ts":"2019-04-15T20:37:24.702Z","caller":"receive_adapter/main.go:99","msg":"Starting Apache Kafka Receive Adapter...","bootstrap_server":"...","Topics":"knative-demo-topic","ConsumerGroup":"knative-group","SinkURI":"...","TLS":false}
+   {"level":"info","ts":"2019-04-15T20:37:24.702Z","caller":"adapter/adapter.go:100","msg":"Starting with config: ","bootstrap_server":"...","Topics":"knative-demo-topic","ConsumerGroup":"knative-group","SinkURI":"...","TLS":false}
+   {"level":"info","ts":1553034726.546107,"caller":"adapter/adapter.go:154","msg":"Successfully sent event to sink"}
    ```
+
 3. Ensure the Event Display received the message sent to it by the Event Source.
 
    ```

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,16 +17,17 @@ limitations under the License.
 package controller
 
 import (
+	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(manager.Manager, *zap.SugaredLogger) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, l *zap.SugaredLogger) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, l); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/sdk/provider.go
+++ b/pkg/controller/sdk/provider.go
@@ -19,6 +19,7 @@ package sdk
 import (
 	"context"
 
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -45,12 +46,13 @@ type Provider struct {
 }
 
 // ProvideController returns a controller for controller-runtime.
-func (p *Provider) Add(mgr manager.Manager) error {
+func (p *Provider) Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 	// Setup a new controller to Reconcile Subscriptions.
 	c, err := controller.New(p.AgentName, mgr, controller.Options{
 		Reconciler: &Reconciler{
 			provider: *p,
 			recorder: mgr.GetRecorder(p.AgentName),
+			logger:   *logger,
 		},
 	})
 	if err != nil {

--- a/pkg/controller/sdk/reconciler.go
+++ b/pkg/controller/sdk/reconciler.go
@@ -36,6 +36,7 @@ type Reconciler struct {
 	client   client.Client
 	recorder record.EventRecorder
 	scheme   *runtime.Scheme
+	logger   zap.SugaredLogger
 
 	provider Provider
 }
@@ -46,8 +47,8 @@ var _ reconcile.Reconciler = &Reconciler{}
 // Reconcile compares the actual state with the desired, and attempts to
 // converge the two.
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	ctx := context.TODO()
-	logger := logging.FromContext(ctx)
+	ctx := logging.WithLogger(context.TODO(), r.logger.With(zap.Any("request", request)))
+	logger := r.logger
 
 	logger.Infof("Reconciling %s %v", r.provider.Parent.GetObjectKind(), request)
 

--- a/pkg/controller/sdk/reconciler.go
+++ b/pkg/controller/sdk/reconciler.go
@@ -48,7 +48,7 @@ var _ reconcile.Reconciler = &Reconciler{}
 // converge the two.
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := logging.WithLogger(context.TODO(), r.logger.With(zap.Any("request", request)))
-	logger := r.logger
+	logger := logging.FromContext(ctx)
 
 	logger.Infof("Reconciling %s %v", r.provider.Parent.GetObjectKind(), request)
 

--- a/pkg/reconciler/awssqssource/awssqssource.go
+++ b/pkg/reconciler/awssqssource/awssqssource.go
@@ -62,7 +62,7 @@ const (
 // Add creates a new AwsSqsSource Controller and adds it to the Manager with
 // default RBAC. The Manager will set fields on the Controller and Start it when
 // the Manager is Started.
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 	if enabled, defined := os.LookupEnv(awsSqsEnabledEnvVar); !defined || enabled != "true" {
 		log.Println("Skipping the AWS SQS Source controller.")
 		return nil
@@ -83,7 +83,7 @@ func Add(mgr manager.Manager) error {
 		},
 	}
 
-	return p.Add(mgr)
+	return p.Add(mgr, logger)
 }
 
 type reconciler struct {

--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -51,7 +51,7 @@ const (
 // Add creates a new ContainerSource Controller and adds it to the Manager with
 // default RBAC. The Manager will set fields on the Controller and Start it when
 // the Manager is Started.
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 	p := &sdk.Provider{
 		AgentName: controllerAgentName,
 		Parent:    &v1alpha1.ContainerSource{},
@@ -62,7 +62,7 @@ func Add(mgr manager.Manager) error {
 		},
 	}
 
-	return p.Add(mgr)
+	return p.Add(mgr, logger)
 }
 
 type reconciler struct {

--- a/pkg/reconciler/cronjobsource/cronjobsource.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource.go
@@ -55,7 +55,7 @@ const (
 // Add creates a new CronJobSource Controller and adds it to the Manager with
 // default RBAC. The Manager will set fields on the Controller and Start it when
 // the Manager is Started.
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 	raImage, defined := os.LookupEnv(raImageEnvVar)
 	if !defined {
 		return fmt.Errorf("required environment variable %q not defined", raImageEnvVar)
@@ -72,7 +72,7 @@ func Add(mgr manager.Manager) error {
 		},
 	}
 
-	return p.Add(mgr)
+	return p.Add(mgr, logger)
 }
 
 type reconciler struct {

--- a/pkg/reconciler/githubsource/githubsource.go
+++ b/pkg/reconciler/githubsource/githubsource.go
@@ -53,7 +53,7 @@ const (
 // Add creates a new GitHubSource Controller and adds it to the
 // Manager with default RBAC. The Manager will set fields on the
 // Controller and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 	receiveAdapterImage, defined := os.LookupEnv(raImageEnvVar)
 	if !defined {
 		return fmt.Errorf("required environment variable %q not defined", raImageEnvVar)
@@ -71,7 +71,7 @@ func Add(mgr manager.Manager) error {
 		},
 	}
 
-	return p.Add(mgr)
+	return p.Add(mgr, logger)
 }
 
 // reconciler reconciles a GitHubSource object

--- a/pkg/reconciler/kuberneteseventsource/kuberneteseventsource.go
+++ b/pkg/reconciler/kuberneteseventsource/kuberneteseventsource.go
@@ -52,6 +52,7 @@ type reconciler struct {
 	recorder            record.EventRecorder
 	scheme              *runtime.Scheme
 	receiveAdapterImage string
+	logger              *zap.SugaredLogger
 }
 
 var _ reconcile.Reconciler = &reconciler{}
@@ -59,21 +60,22 @@ var _ reconcile.Reconciler = &reconciler{}
 // Add creates a new KubernetesEventSource Controller and adds it to the Manager
 // with default RBAC. The Manager will set fields on the Controller and Start it
 // when the Manager is Started.
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 	receiveAdapterImage, defined := os.LookupEnv(raImageEnvVar)
 	if !defined {
 		return fmt.Errorf("required environment variable %q not defined", raImageEnvVar)
 	}
 
-	return add(mgr, newReconciler(mgr, receiveAdapterImage))
+	return add(mgr, newReconciler(mgr, receiveAdapterImage, logger))
 }
 
-func newReconciler(mgr manager.Manager, receiveAdapterImage string) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, receiveAdapterImage string, logger *zap.SugaredLogger) reconcile.Reconciler {
 	return &reconciler{
 		Client:              mgr.GetClient(),
 		scheme:              mgr.GetScheme(),
 		recorder:            mgr.GetRecorder(controllerAgentName),
 		receiveAdapterImage: receiveAdapterImage,
+		logger:              logger,
 	}
 }
 


### PR DESCRIPTION
Fixes #332

Currently, event-sources don't properly set, or receive their loggers
from context.  Change this to set the initial logger in both the
event-source, as well as the underlying receiver.