### PR TITLE
Update k8s test image, sdk now blocks on receive

### DIFF
--- a/test/test_images/k8sevents/function.go
+++ b/test/test_images/k8sevents/function.go
@@ -37,17 +37,13 @@ func receive(event cloudevents.Event) {
 }
 
 func main() {
-	ctx := context.TODO()
-
 	c, err := kncloudevents.NewDefaultClient()
 	if err != nil {
 		log.Fatalf("failed to create client: %s", err.Error())
 	}
 
-	if err := c.StartReceiver(ctx, receive); err != nil {
+	log.Print("listening on port 8080")
+	if err := c.StartReceiver(context.Background(), receive); err != nil {
 		log.Fatalf("failed to start receiver: %s", err.Error())
 	}
-
-	log.Print("Ready and listening on port 8080")
-	<-ctx.Done()
 }


### PR DESCRIPTION
## Proposed Changes

  * Minor cleanup of the test image for running k8s e2e test, the sdk blocks when receive is called.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```