### PR TITLE
golang format tools

### DIFF
--- a/contrib/apiserver/pkg/adapter/adapter_test.go
+++ b/contrib/apiserver/pkg/adapter/adapter_test.go
@@ -54,7 +54,7 @@ type testCase struct {
 
 func TestReconcile(t *testing.T) {
 	testCases := []testCase{
-		testCase{
+		{
 			TestCase: controllertesting.TestCase{
 				Name: "Receive Pod creation event",
 				InitialState: []runtime.Object{

--- a/contrib/apiserver/pkg/controller/apiserversource/apiserversource_controller_test.go
+++ b/contrib/apiserver/pkg/controller/apiserversource/apiserversource_controller_test.go
@@ -115,7 +115,7 @@ func getSource() *sourcesv1alpha1.ApiServerSource {
 		ObjectMeta: om(testNS, sourceName),
 		Spec: sourcesv1alpha1.ApiServerSourceSpec{
 			Resources: []sourcesv1alpha1.Kind{
-				sourcesv1alpha1.Kind{
+				{
 					APIVersion: "",
 					Kind:       "Namespace",
 				},

--- a/contrib/apiserver/pkg/controller/apiserversource/resources/receive_adapter_test.go
+++ b/contrib/apiserver/pkg/controller/apiserversource/resources/receive_adapter_test.go
@@ -35,11 +35,11 @@ func TestMakeReceiveAdapter(t *testing.T) {
 		Spec: v1alpha1.ApiServerSourceSpec{
 			ServiceAccountName: "source-svc-acct",
 			Resources: []v1alpha1.Kind{
-				v1alpha1.Kind{
+				{
 					APIVersion: "",
 					Kind:       "Namespace",
 					OwnerReferences: []metav1.OwnerReference{
-						metav1.OwnerReference{
+						{
 							APIVersion: "",
 							Kind:       "Pod",
 						},

--- a/pkg/kncloudevents/good_client.go
+++ b/pkg/kncloudevents/good_client.go
@@ -1,7 +1,7 @@
 package kncloudevents
 
 import (
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
