### PR TITLE
Update test-infra: some fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -254,7 +254,6 @@
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
-  branch = "master"
   digest = "1:010d46ea3c1e730897e53058d1013a963f3f987675dda87df64f891b945281db"
   name = "github.com/google/go-cmp"
   packages = [
@@ -508,14 +507,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f3c8dc03bb88bca90c59550e06b0f27a6ca489b1747ac8e5153686a6752e4d74"
+  digest = "1:d0d25d17a6ef5842ad4c0ea41af24bd3debd8f6c7f0f18cd49db690962a84a83"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "3a09cd7f5428743509941d116fdee644041a3507"
+  revision = "03b0eab127a39bccf71c1eadc3446f7fb13f8669"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -507,14 +507,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d0d25d17a6ef5842ad4c0ea41af24bd3debd8f6c7f0f18cd49db690962a84a83"
+  digest = "1:f27efa11fb1aec3e502e2ed95d9a1211a93f8a791b7da0a06fdade0d98de5008"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "03b0eab127a39bccf71c1eadc3446f7fb13f8669"
+  revision = "75f6ca1c4dc3b3ae5dc1a1a433753957a9340e83"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -95,7 +95,7 @@ function dump_extra_cluster_state() {
 
 # Script entry point.
 
-initialize $@
+initialize $@ --skip-istio
 
 go_test_e2e ./test/e2e || fail_test
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -95,7 +95,7 @@ function dump_extra_cluster_state() {
 
 # Script entry point.
 
-initialize $@ --skip-istio
+initialize $@
 
 go_test_e2e ./test/e2e || fail_test
 

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -172,6 +172,9 @@ This is a helper script for Knative E2E test scripts. To use it:
    will immediately start the tests against the cluster currently configured for
    `kubectl`.
 
+1. By default Istio is installed on the cluster via Addon, using `--skip-istio` if
+   you choose not to have it preinstalled.
+
 1. You can force running the tests against a specific GKE cluster version by using
    the `--cluster-version` flag and passing a full version as the flag value.
 

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -155,8 +155,9 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
    (or `report_go_test()` if you need a more fine-grained control) and call
    `fail_test()` or `success()` if any of them failed. The environment variable
-   `KO_DOCKER_REPO` will be set according to the test cluster. You can also use
-   the following boolean (0 is false, 1 is true) environment variables for the logic:
+   `KO_DOCKER_REPO` and `E2E_PROJECT_ID` will be set according to the test cluster.
+   You can also use the following boolean (0 is false, 1 is true) environment
+   variables for the logic:
 
    - `EMIT_METRICS`: true if `--emit-metrics` was passed.
 

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -166,7 +166,7 @@ function create_test_cluster() {
 
   # Smallest cluster required to run the end-to-end-tests
   local CLUSTER_CREATION_ARGS=(
-    --gke-create-command="container clusters create --quiet --enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate ${EXTRA_CLUSTER_CREATION_FLAGS[@]}"
+    --gke-create-command="container clusters create --quiet --enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate ${GKE_ADDONS} ${EXTRA_CLUSTER_CREATION_FLAGS[@]}"
     --gke-shape={\"default\":{\"Nodes\":${E2E_MIN_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
     --provider=gke
     --deployment=gke
@@ -349,9 +349,11 @@ function fail_test() {
 RUN_TESTS=0
 EMIT_METRICS=0
 SKIP_KNATIVE_SETUP=0
+SKIP_ISTIO=0
 GCP_PROJECT=""
 E2E_SCRIPT=""
 E2E_CLUSTER_VERSION=""
+GKE_ADDONS=""
 EXTRA_CLUSTER_CREATION_FLAGS=()
 EXTRA_KUBETEST_FLAGS=()
 E2E_SCRIPT_CUSTOM_FLAGS=()
@@ -383,6 +385,7 @@ function initialize() {
       --run-tests) RUN_TESTS=1 ;;
       --emit-metrics) EMIT_METRICS=1 ;;
       --skip-knative-setup) SKIP_KNATIVE_SETUP=1 ;;
+      --skip-istio) SKIP_ISTIO=1 ;;
       *)
         [[ $# -ge 2 ]] || abort "missing parameter after $1"
         shift
@@ -412,6 +415,8 @@ function initialize() {
   is_protected_gcr ${KO_DOCKER_REPO} && \
     abort "\$KO_DOCKER_REPO set to ${KO_DOCKER_REPO}, which is forbidden"
 
+  (( SKIP_ISTIO )) || GKE_ADDONS="--addons=Istio"
+
   readonly RUN_TESTS
   readonly EMIT_METRICS
   readonly GCP_PROJECT
@@ -419,6 +424,7 @@ function initialize() {
   readonly EXTRA_CLUSTER_CREATION_FLAGS
   readonly EXTRA_KUBETEST_FLAGS
   readonly SKIP_KNATIVE_SETUP
+  readonly GKE_ADDONS
 
   if (( ! RUN_TESTS )); then
     create_test_cluster

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -67,6 +67,8 @@ IS_BOSKOS=0
 
 # Tear down the test resources.
 function teardown_test_resources() {
+  # On boskos, save time and don't teardown as the cluster will be destroyed anyway.
+  (( IS_BOSKOS )) && return
   header "Tearing down test environment"
   function_exists test_teardown && test_teardown
   (( ! SKIP_KNATIVE_SETUP )) && function_exists knative_teardown && knative_teardown
@@ -113,8 +115,7 @@ function save_metadata() {
     geo_key="Zone"
     geo_value="${E2E_CLUSTER_REGION}-${E2E_CLUSTER_ZONE}"
   fi
-  local gcloud_project="$(gcloud config get-value project)"
-  local cluster_version="$(gcloud container clusters list --project=${gcloud_project} --format='value(currentMasterVersion)')"
+  local cluster_version="$(gcloud container clusters list --project=${E2E_PROJECT_ID} --format='value(currentMasterVersion)')"
   cat << EOF > ${ARTIFACTS}/metadata.json
 {
   "E2E:${geo_key}": "${geo_value}",
@@ -130,6 +131,7 @@ EOF
 # See https://github.com/knative/serving/issues/959 for details.
 # TODO(adrcunha): Remove once the leak issue is resolved.
 function delete_leaked_network_resources() {
+  # On boskos, don't bother with leaks as the janitor will delete everything in the project.
   (( IS_BOSKOS )) && return
   # Ensure we're using the GCP project used by kubetest
   local gcloud_project="$(gcloud config get-value project)"
@@ -256,7 +258,7 @@ function create_test_cluster_with_retries() {
       # Exit if test succeeded
       [[ "$(get_test_return_code)" == "0" ]] && return
       # If test failed not because of cluster creation stockout, return
-      [[ -z "$(grep -Eio 'does not have enough resources to fulfill the request' ${cluster_creation_log})" ]] && return
+      [[ -z "$(grep -Eio 'does not have enough resources available to fulfill the request' ${cluster_creation_log})" ]] && return
     done
   done
 }
@@ -269,6 +271,11 @@ function setup_test_cluster() {
 
   header "Setting up test cluster"
 
+  # Set the actual project the test cluster resides in
+  # It will be a project assigned by Boskos if test is running on Prow, 
+  # otherwise will be ${GCP_PROJECT} set up by user.
+  readonly export E2E_PROJECT_ID="$(gcloud config get-value project)"
+
   # Save some metadata about cluster creation for using in prow and testgrid
   save_metadata
 
@@ -280,9 +287,10 @@ function setup_test_cluster() {
   if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then
     acquire_cluster_admin_role ${k8s_user} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
     kubectl config set-context ${k8s_cluster} --namespace=default
-    export KO_DOCKER_REPO=gcr.io/$(gcloud config get-value project)/${E2E_BASE_NAME}-e2e-img
+    export KO_DOCKER_REPO=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img
   fi
 
+  echo "- Project is ${E2E_PROJECT_ID}"
   echo "- Cluster is ${k8s_cluster}"
   echo "- User is ${k8s_user}"
   echo "- Docker is ${KO_DOCKER_REPO}"
@@ -303,7 +311,7 @@ function setup_test_cluster() {
   fi
 }
 
-# Gets the exit of of the test script.
+# Gets the exit of the test script.
 # For more details, see set_test_return_code().
 function get_test_return_code() {
   echo $(cat ${TEST_RESULT_FILE})

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -321,14 +321,6 @@ function report_go_test() {
 # Install the latest stable Knative/serving in the current cluster.
 function start_latest_knative_serving() {
   header "Starting Knative Serving"
-  subheader "Installing Istio"
-  echo "Running Istio CRD from ${KNATIVE_ISTIO_CRD_YAML}"
-  kubectl apply -f ${KNATIVE_ISTIO_CRD_YAML} || return 1
-  wait_until_batch_job_complete istio-system || return 1
-  echo "Installing Istio from ${KNATIVE_ISTIO_YAML}"
-  kubectl apply -f ${KNATIVE_ISTIO_YAML} || return 1
-  wait_until_pods_running istio-system || return 1
-  kubectl label namespace default istio-injection=enabled || return 1
   subheader "Installing Knative Serving"
   echo "Installing Serving from ${KNATIVE_SERVING_RELEASE}"
   kubectl apply -f ${KNATIVE_SERVING_RELEASE} || return 1

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -43,7 +43,7 @@ IS_DOCUMENTATION_PR=0
 # Returns true if PR only contains the given file regexes.
 # Parameters: $1 - file regexes, space separated.
 function pr_only_contains() {
-  [[ -z "$(echo "${CHANGED_FILES}" | grep -v \(${1// /\\|}\)$))" ]]
+  [[ -z "$(echo "${CHANGED_FILES}" | grep -v "\(${1// /\\|}\)$")" ]]
 }
 
 # List changed files in the current PR.


### PR DESCRIPTION
Update vendor: knative/test-infra. 

- fix for retrying different GCP regions when e2e test failed due to stock out
- Istio install from GKE Addon