### PR TITLE
remove duplicated keys

### DIFF
--- a/contrib/kafka/config/300-kafkasource.yaml
+++ b/contrib/kafka/config/300-kafkasource.yaml
@@ -52,8 +52,6 @@ spec:
             consumerGroup:
               type: string
               minLength: 1
-            consumerGroup:
-              type: string
             net:
               properties:
                 sasl:
@@ -81,8 +79,6 @@ spec:
               type: string
             sink:
               type: object
-            topics:
-              type: string
           type: object
           required:
               - bootstrapServers


### PR DESCRIPTION
Follow up from @danp' #351  

the generation did re-order keys, and they got accidentally added (as dup)
