### PR TITLE
GitHub source cosmetic change

### DIFF
--- a/pkg/adapter/github/adapter.go
+++ b/pkg/adapter/github/adapter.go
@@ -50,12 +50,13 @@ func New(sinkURI, ownerRepo string) (*Adapter, error) {
 	if err != nil {
 		return nil, err
 	}
-	a.source = sourcesv1alpha1.GitHubEventSource(ownerRepo)
+	source := sourcesv1alpha1.GitHubEventSource(ownerRepo)
 	// Check at startup if it's not a URLRef and return an error in that case.
-	source := cloudevents.ParseURLRef(a.source)
-	if source == nil {
-		return nil, fmt.Errorf("invalid source for github events: %s", a.source)
+	src := cloudevents.ParseURLRef(source)
+	if src == nil {
+		return nil, fmt.Errorf("invalid source for github events: %s", source)
 	}
+	a.source = source
 	return a, nil
 }
 


### PR DESCRIPTION
## Proposed Changes

  * Cosmetic change suggested by @rootfs in https://github.com/knative/eventing-sources/pull/392#discussion_r281303588 but was after the lgtm

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```