### PR TITLE
awssqs: fix breakage after moving to contrib/

### DIFF
--- a/contrib/awssqs/config/201-clusterrole.yaml
+++ b/contrib/awssqs/config/201-clusterrole.yaml
@@ -22,13 +22,27 @@ rules:
   resources:
   - deployments
   verbs:
-  - *
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+
 - apiGroups:
   - ""
   resources:
   - events
   verbs:
-  - *
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+
 - apiGroups:
   - sources.eventing.knative.dev
   resources:

--- a/contrib/awssqs/pkg/apis/addtoscheme_eventing_v1alpha1.go
+++ b/contrib/awssqs/pkg/apis/addtoscheme_eventing_v1alpha1.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+)
+
+func init() {
+	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
+	AddToSchemes = append(AddToSchemes, eventingv1alpha1.SchemeBuilder.AddToScheme)
+}


### PR DESCRIPTION
Fixes two issues introduced at f62c2387. (See https://github.com/knative/eventing-sources/pull/253)