### PR TITLE
contrib/kafka: support cert, key, and caCert in spec.net.tls

### DIFF
--- a/contrib/kafka/cmd/receive_adapter/main.go
+++ b/contrib/kafka/cmd/receive_adapter/main.go
@@ -41,6 +41,9 @@ const (
 	envNetSASLUser      = "KAFKA_NET_SASL_USER"
 	envNetSASLPassword  = "KAFKA_NET_SASL_PASSWORD"
 	envNetTLSEnable     = "KAFKA_NET_TLS_ENABLE"
+	envNetTLSCert       = "KAFKA_NET_TLS_CERT"
+	envNetTLSKey        = "KAFKA_NET_TLS_KEY"
+	envNetTLSCACert     = "KAFKA_NET_TLS_CA_CERT"
 	envSinkURI          = "SINK_URI"
 )
 
@@ -91,6 +94,9 @@ func main() {
 			},
 			TLS: kafka.AdapterTLS{
 				Enable: getOptionalBoolEnv(envNetTLSEnable),
+				Cert:   os.Getenv(envNetTLSCert),
+				Key:    os.Getenv(envNetTLSKey),
+				CACert: os.Getenv(envNetTLSCACert),
 			},
 		},
 	}
@@ -98,11 +104,12 @@ func main() {
 	stopCh := signals.SetupSignalHandler()
 
 	logger.Info("Starting Apache Kafka Receive Adapter...",
-		zap.String("bootstrap_server", adapter.BootstrapServers),
+		zap.String("BootstrapServers", adapter.BootstrapServers),
 		zap.String("Topics", adapter.Topics),
 		zap.String("ConsumerGroup", adapter.ConsumerGroup),
 		zap.String("SinkURI", adapter.SinkURI),
-		zap.Bool("TLS", adapter.Net.SASL.Enable))
+		zap.Bool("SASL", adapter.Net.SASL.Enable),
+		zap.Bool("TLS", adapter.Net.TLS.Enable))
 	if err := adapter.Start(ctx, stopCh); err != nil {
 		logger.Fatal("failed to start adapter: ", zap.Error(err))
 	}

--- a/contrib/kafka/config/300-kafkasource.yaml
+++ b/contrib/kafka/config/300-kafkasource.yaml
@@ -71,8 +71,23 @@ spec:
                   type: object
                 tls:
                   properties:
+                    caCert:
+                      properties:
+                        secretKeyRef:
+                          type: object
+                      type: object
+                    cert:
+                      properties:
+                        secretKeyRef:
+                          type: object
+                      type: object
                     enable:
                       type: boolean
+                    key:
+                      properties:
+                        secretKeyRef:
+                          type: object
+                      type: object
                   type: object
               type: object
             serviceAccountName:

--- a/contrib/kafka/pkg/adapter/adapter.go
+++ b/contrib/kafka/pkg/adapter/adapter.go
@@ -17,9 +17,12 @@ limitations under the License.
 package kafka
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
@@ -40,6 +43,9 @@ type AdapterSASL struct {
 
 type AdapterTLS struct {
 	Enable bool
+	Cert   string
+	Key    string
+	CACert string
 }
 
 type AdapterNet struct {
@@ -95,11 +101,12 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 	logger := logging.FromContext(ctx)
 
 	logger.Infow("Starting with config: ",
-		zap.String("bootstrap_server", a.BootstrapServers),
+		zap.String("BootstrapServers", a.BootstrapServers),
 		zap.String("Topics", a.Topics),
 		zap.String("ConsumerGroup", a.ConsumerGroup),
 		zap.String("SinkURI", a.SinkURI),
-		zap.Bool("TLS", a.Net.SASL.Enable))
+		zap.Bool("SASL", a.Net.SASL.Enable),
+		zap.Bool("TLS", a.Net.TLS.Enable))
 
 	kafkaConfig := sarama.NewConfig()
 	kafkaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
@@ -109,6 +116,14 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 	kafkaConfig.Net.SASL.User = a.Net.SASL.User
 	kafkaConfig.Net.SASL.Password = a.Net.SASL.Password
 	kafkaConfig.Net.TLS.Enable = a.Net.TLS.Enable
+
+	if a.Net.TLS.Enable {
+		tlsConfig, err := newTLSConfig(a.Net.TLS.Cert, a.Net.TLS.Key, a.Net.TLS.CACert)
+		if err != nil {
+			panic(err)
+		}
+		kafkaConfig.Net.TLS.Config = tlsConfig
+	}
 
 	// Start with a client
 	client, err := sarama.NewClient(strings.Split(a.BootstrapServers, ","), kafkaConfig)
@@ -182,5 +197,70 @@ func (a *Adapter) jsonEncode(ctx context.Context, value []byte) interface{} {
 		return value
 	} else {
 		return payload
+	}
+}
+
+// newTLSConfig returns a *tls.Config using the given client cert, client key,
+// and CA certificate. If none are appropriate, a nil *tls.Config is returned.
+func newTLSConfig(clientCert, clientKey, caCert string) (*tls.Config, error) {
+	valid := false
+
+	config := &tls.Config{}
+
+	if clientCert != "" && clientKey != "" {
+		cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
+		if err != nil {
+			return nil, err
+		}
+		config.Certificates = []tls.Certificate{cert}
+		config.BuildNameToCertificate()
+		valid = true
+	}
+
+	if caCert != "" {
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM([]byte(caCert))
+		config.RootCAs = caCertPool
+		// The CN of Heroku Kafka certs do not match the hostname of the
+		// broker, but Go's default TLS behavior requires that they do.
+		config.VerifyPeerCertificate = verifyCertSkipHostname(caCertPool)
+		config.InsecureSkipVerify = true
+		valid = true
+	}
+
+	if !valid {
+		config = nil
+	}
+
+	return config, nil
+}
+
+// verifyCertSkipHostname verifies certificates in the same way that the
+// default TLS handshake does, except it skips hostname verification. It must
+// be used with InsecureSkipVerify.
+func verifyCertSkipHostname(roots *x509.CertPool) func([][]byte, [][]*x509.Certificate) error {
+	return func(certs [][]byte, _ [][]*x509.Certificate) error {
+		opts := x509.VerifyOptions{
+			Roots:         roots,
+			CurrentTime:   time.Now(),
+			Intermediates: x509.NewCertPool(),
+		}
+
+		leaf, err := x509.ParseCertificate(certs[0])
+		if err != nil {
+			return err
+		}
+
+		for _, asn1Data := range certs[1:] {
+			cert, err := x509.ParseCertificate(asn1Data)
+			if err != nil {
+				return err
+			}
+
+			opts.Intermediates.AddCert(cert)
+		}
+
+		_, err = leaf.Verify(opts)
+		return err
 	}
 }

--- a/contrib/kafka/pkg/adapter/adapter_test.go
+++ b/contrib/kafka/pkg/adapter/adapter_test.go
@@ -17,9 +17,16 @@ limitations under the License.
 package kafka
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"io/ioutil"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -106,6 +113,140 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 	}
 }
 
+func TestNewTLSConfig(t *testing.T) {
+	cert, key := generateCert(t)
+
+	for _, tt := range []struct {
+		name       string
+		cert       string
+		key        string
+		caCert     string
+		wantErr    bool
+		wantNil    bool
+		wantClient bool
+		wantServer bool
+	}{
+		{
+			name:    "all empty",
+			wantNil: true,
+		},
+		{
+			name:    "bad input",
+			cert:    "x",
+			key:     "y",
+			caCert:  "z",
+			wantErr: true,
+		},
+		{
+			name:    "only cert",
+			cert:    cert,
+			wantNil: true,
+		},
+		{
+			name:    "only key",
+			key:     key,
+			wantNil: true,
+		},
+		{
+			name:       "cert and key",
+			cert:       cert,
+			key:        key,
+			wantClient: true,
+		},
+		{
+			name:       "only caCert",
+			caCert:     cert,
+			wantServer: true,
+		},
+		{
+			name:       "cert, key, and caCert",
+			cert:       cert,
+			key:        key,
+			caCert:     cert,
+			wantClient: true,
+			wantServer: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := newTLSConfig(tt.cert, tt.key, tt.caCert)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("wanted error")
+				}
+				return
+			}
+
+			if tt.wantNil {
+				if c != nil {
+					t.Fatal("wanted non-nil config")
+				}
+				return
+			}
+
+			var wantCertificates int
+			if tt.wantClient {
+				wantCertificates = 1
+			} else {
+				wantCertificates = 0
+			}
+			if got, want := len(c.Certificates), wantCertificates; got != want {
+				t.Errorf("got %d Certificates, wanted %d", got, want)
+			}
+
+			if tt.wantServer {
+				if c.RootCAs == nil {
+					t.Error("wanted non-nil RootCAs")
+				}
+
+				if c.VerifyPeerCertificate == nil {
+					t.Error("wanted non-nil VerifyPeerCertificate")
+				}
+
+				if !c.InsecureSkipVerify {
+					t.Error("wanted InsecureSkipVerify")
+				}
+			} else {
+				if c.RootCAs != nil {
+					t.Error("wanted nil RootCAs")
+				}
+
+				if c.VerifyPeerCertificate != nil {
+					t.Error("wanted nil VerifyPeerCertificate")
+				}
+
+				if c.InsecureSkipVerify {
+					t.Error("wanted false InsecureSkipVerify")
+				}
+			}
+		})
+	}
+
+}
+
+func TestVerifyCertSkipHostname(t *testing.T) {
+	cert, _ := generateCert(t)
+	certPem, _ := pem.Decode([]byte(cert))
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM([]byte(cert))
+
+	v := verifyCertSkipHostname(caCertPool)
+
+	err := v([][]byte{certPem.Bytes}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert2, _ := generateCert(t)
+	cert2Pem, _ := pem.Decode([]byte(cert2))
+
+	err = v([][]byte{cert2Pem.Bytes}, nil)
+	// Error expected as we're still verifying with the first cert.
+	if err == nil {
+		t.Fatal("wanted error")
+	}
+}
+
 type fakeHandler struct {
 	body   []byte
 	header http.Header
@@ -132,4 +273,54 @@ func sinkAccepted(writer http.ResponseWriter, req *http.Request) {
 
 func sinkRejected(writer http.ResponseWriter, _ *http.Request) {
 	writer.WriteHeader(http.StatusRequestTimeout)
+}
+
+// Lifted from the RSA path of https://golang.org/src/crypto/tls/generate_cert.go.
+func generateCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	notBefore := time.Now().Add(-5 * time.Minute)
+	notAfter := notBefore.Add(time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var certOut bytes.Buffer
+	if err := pem.Encode(&certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		t.Fatal(err)
+	}
+
+	var keyOut bytes.Buffer
+	if err := pem.Encode(&keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
+		t.Fatal(err)
+	}
+
+	return certOut.String(), keyOut.String()
 }

--- a/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go
+++ b/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go
@@ -63,6 +63,16 @@ type KafkaSourceSASLSpec struct {
 
 type KafkaSourceTLSSpec struct {
 	Enable bool `json:"enable,omitempty"`
+
+	// Cert is the Kubernetes secret containing the client certificate.
+	// +optional
+	Cert sourcesv1alpha1.SecretValueFromSource `json:"cert,omitempty"`
+	// Key is the Kubernetes secret containing the client key.
+	// +optional
+	Key sourcesv1alpha1.SecretValueFromSource `json:"key,omitempty"`
+	// CACert is the Kubernetes secret containing the server CA cert.
+	// +optional
+	CACert sourcesv1alpha1.SecretValueFromSource `json:"caCert,omitempty"`
 }
 
 type KafkaSourceNetSpec struct {

--- a/contrib/kafka/pkg/reconciler/resources/receive_adapter.go
+++ b/contrib/kafka/pkg/reconciler/resources/receive_adapter.go
@@ -63,23 +63,12 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 		},
 	}
 
-	if args.Source.Spec.Net.SASL.User.SecretKeyRef != nil {
-		env = append(env, corev1.EnvVar{
-			Name: "KAFKA_NET_SASL_USER",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: args.Source.Spec.Net.SASL.User.SecretKeyRef,
-			},
-		})
-	}
+	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_SASL_USER", args.Source.Spec.Net.SASL.User.SecretKeyRef)
+	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_SASL_PASSWORD", args.Source.Spec.Net.SASL.Password.SecretKeyRef)
 
-	if args.Source.Spec.Net.SASL.Password.SecretKeyRef != nil {
-		env = append(env, corev1.EnvVar{
-			Name: "KAFKA_NET_SASL_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: args.Source.Spec.Net.SASL.Password.SecretKeyRef,
-			},
-		})
-	}
+	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_TLS_CERT", args.Source.Spec.Net.TLS.Cert.SecretKeyRef)
+	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_TLS_KEY", args.Source.Spec.Net.TLS.Key.SecretKeyRef)
+	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_TLS_CA_CERT", args.Source.Spec.Net.TLS.CACert.SecretKeyRef)
 
 	return &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -112,4 +101,22 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 			},
 		},
 	}
+}
+
+// appendEnvFromSecretKeyRef returns env with an EnvVar appended
+// setting key to the secret and key described by ref.
+// If ref is nil, env is returned unchanged.
+func appendEnvFromSecretKeyRef(env []corev1.EnvVar, key string, ref *corev1.SecretKeySelector) []corev1.EnvVar {
+	if ref == nil {
+		return env
+	}
+
+	env = append(env, corev1.EnvVar{
+		Name: key,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: ref,
+		},
+	})
+
+	return env
 }

--- a/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
+++ b/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
@@ -60,6 +60,30 @@ func TestMakeReceiveAdapter(t *testing.T) {
 				},
 				TLS: v1alpha1.KafkaSourceTLSSpec{
 					Enable: true,
+					Cert: sourcesv1alpha1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "the-cert-secret",
+							},
+							Key: "tls.crt",
+						},
+					},
+					Key: sourcesv1alpha1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "the-key-secret",
+							},
+							Key: "tls.key",
+						},
+					},
+					CACert: sourcesv1alpha1.SecretValueFromSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "the-ca-cert-secret",
+							},
+							Key: "tls.crt",
+						},
+					},
 				},
 			},
 		},
@@ -155,6 +179,135 @@ func TestMakeReceiveAdapter(t *testing.T) {
 											Key: "password",
 										},
 									},
+								},
+								{
+									Name: "KAFKA_NET_TLS_CERT",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "the-cert-secret",
+											},
+											Key: "tls.crt",
+										},
+									},
+								},
+								{
+									Name: "KAFKA_NET_TLS_KEY",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "the-key-secret",
+											},
+											Key: "tls.key",
+										},
+									},
+								},
+								{
+									Name: "KAFKA_NET_TLS_CA_CERT",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "the-ca-cert-secret",
+											},
+											Key: "tls.crt",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected deploy (-want, +got) = %v", diff)
+	}
+}
+
+func TestMakeReceiveAdapterNoNet(t *testing.T) {
+	src := &v1alpha1.KafkaSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "source-name",
+			Namespace: "source-namespace",
+		},
+		Spec: v1alpha1.KafkaSourceSpec{
+			ServiceAccountName: "source-svc-acct",
+			Topics:             "topic1,topic2",
+			BootstrapServers:   "server1,server2",
+			ConsumerGroup:      "group",
+		},
+	}
+
+	got := MakeReceiveAdapter(&ReceiveAdapterArgs{
+		Image:  "test-image",
+		Source: src,
+		Labels: map[string]string{
+			"test-key1": "test-value1",
+			"test-key2": "test-value2",
+		},
+		SinkURI: "sink-uri",
+	})
+
+	one := int32(1)
+	want := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    "source-namespace",
+			GenerateName: "source-name-",
+			Labels: map[string]string{
+				"test-key1": "test-value1",
+				"test-key2": "test-value2",
+			},
+		},
+		Spec: v1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"test-key1": "test-value1",
+					"test-key2": "test-value2",
+				},
+			},
+			Replicas: &one,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "true",
+					},
+					Labels: map[string]string{
+						"test-key1": "test-value1",
+						"test-key2": "test-value2",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "source-svc-acct",
+					Containers: []corev1.Container{
+						{
+							Name:  "receive-adapter",
+							Image: "test-image",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "KAFKA_BOOTSTRAP_SERVERS",
+									Value: "server1,server2",
+								},
+								{
+									Name:  "KAFKA_TOPICS",
+									Value: "topic1,topic2",
+								},
+								{
+									Name:  "KAFKA_CONSUMER_GROUP",
+									Value: "group",
+								},
+								{
+									Name:  "KAFKA_NET_SASL_ENABLE",
+									Value: "false",
+								},
+								{
+									Name:  "KAFKA_NET_TLS_ENABLE",
+									Value: "false",
+								},
+								{
+									Name:  "SINK_URI",
+									Value: "sink-uri",
 								},
 							},
 						},

--- a/contrib/kafka/samples/event-source.yaml
+++ b/contrib/kafka/samples/event-source.yaml
@@ -22,6 +22,12 @@
 #   KAFKA_SASL_PASSWORD_SECRET_NAME: Name of secret containing SASL password (optional)
 #   KAFKA_SASL_PASSWORD_SECRET_KEY: Key within secret containing SASL password (optional)
 #   KAFKA_TLS_ENABLE: Truthy to enable TLS, disabled by default (optional)
+#   KAFKA_TLS_CERT_SECRET_NAME: Name of secret containing client cert to use when connecting wtih TLS (optional)
+#   KAFKA_TLS_CERT_SECRET_KEY: Key within secret containing client cert to use when connecting wtih TLS (optional)
+#   KAFKA_TLS_KEY_SECRET_NAME: Name of secret containing client key to use when connecting wtih TLS (optional)
+#   KAFKA_TLS_KEY_SECRET_KEY: Key within secret containing client key to use when connecting wtih TLS (optional)
+#   KAFKA_TLS_CA_CERT_SECRET_NAME: Name of secret containing server CA cert to use when connecting wtih TLS (optional)
+#   KAFKA_TLS_CA_CERT_SECRET_KEY: Key within secret containing server CA cert to use when connecting wtih TLS (optional)
 
 apiVersion: sources.eventing.knative.dev/v1alpha1
 kind: KafkaSource
@@ -44,6 +50,18 @@ spec:
           key: KAFKA_SASL_PASSWORD_SECRET_KEY
     tls:
       enable: KAFKA_TLS_ENABLE
+      cert:
+        secretKeyRef:
+          name: KAFKA_TLS_CERT_SECRET_NAME
+          key: KAFKA_TLS_CERT_SECRET_KEY
+      key:
+        secretKeyRef:
+          name: KAFKA_TLS_KEY_SECRET_NAME
+          key: KAFKA_TLS_KEY_SECRET_KEY
+      caCert:
+        secretKeyRef:
+          name: KAFKA_TLS_CA_CERT_SECRET_NAME
+          key: KAFKA_TLS_CA_CERT_SECRET_KEY
   sink:
     apiVersion: serving.knative.dev/v1alpha1
     kind: Service


### PR DESCRIPTION
## Proposed Changes

  * Add cert, key, and caCert attributes to KafkaSource's spec.net.tls object
  * Support these new attributes when spec.net.tls.enable is true

**Release Note**
```release-note
KafkaSource now supports configuring client certificate and key and server CA cert via new `spec.net.tls.cert`, `spec.net.tls.key`, and `spec.net.tls.caCert` attributes.
```