### PR TITLE
allow v1services to be addressable

### DIFF
--- a/pkg/controller/sinks/sinks.go
+++ b/pkg/controller/sinks/sinks.go
@@ -42,6 +42,10 @@ func GetSinkURI(ctx context.Context, c client.Client, sink *corev1.ObjectReferen
 	}
 
 	objIdentifier := fmt.Sprintf("\"%s/%s\" (%s)", u.GetNamespace(), u.GetName(), u.GroupVersionKind())
+	// Special case v1/Service to allow it be addressable
+	if u.GroupVersionKind().Kind == "Service" && u.GroupVersionKind().Version == "v1" {
+		return fmt.Sprintf("http://%s.%s.svc/", u.GetName(), u.GetNamespace()), nil
+	}
 
 	t := duckv1alpha1.AddressableType{}
 	err = duck.FromUnstructured(u, &t)

--- a/pkg/controller/sinks/sinks_test.go
+++ b/pkg/controller/sinks/sinks_test.go
@@ -37,6 +37,11 @@ var (
 	addressableKind       = "Sink"
 	addressableAPIVersion = "duck.knative.dev/v1alpha1"
 
+	serviceName       = "test-service"
+	serviceKind       = "Service"
+	serviceAPIVersion = "v1"
+	serviceDNSName    = "http://test-service.testnamespace.svc/"
+
 	unaddressableName       = "testunaddressable"
 	unaddressableKind       = "KResource"
 	unaddressableAPIVersion = "duck.knative.dev/v1alpha1"
@@ -82,6 +87,14 @@ func TestGetSinkURI(t *testing.T) {
 			ref:       nil,
 			wantErr:   fmt.Errorf(`sink ref is nil`),
 		},
+		"v1Service": {
+			objects: []runtime.Object{
+				v1Service(),
+			},
+			namespace: testNS,
+			ref:       getServiceRef(),
+			want:      serviceDNSName,
+		},
 		"nil address": {
 			objects: []runtime.Object{
 				getAddressableNilAddress(),
@@ -125,6 +138,19 @@ func TestGetSinkURI(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func v1Service() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": serviceAPIVersion,
+			"kind":       serviceKind,
+			"metadata": map[string]interface{}{
+				"namespace": testNS,
+				"name":      serviceName,
+			},
+		},
 	}
 }
 
@@ -190,6 +216,14 @@ func getAddressableNilHostname() *unstructured.Unstructured {
 				},
 			},
 		},
+	}
+}
+
+func getServiceRef() *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:       serviceKind,
+		Name:       serviceName,
+		APIVersion: serviceAPIVersion,
 	}
 }
 


### PR DESCRIPTION
Fixes #410 

## Proposed Changes

Allow Service/v1 resources to be special cased and addressable to its conventional hostname.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
Allow Service/v1 resources to be special cased and addressable to its conventional hostname.
```