### PR TITLE
Update test infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -507,14 +507,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f27efa11fb1aec3e502e2ed95d9a1211a93f8a791b7da0a06fdade0d98de5008"
+  digest = "1:b7fed2f0ea8056000867dff3d2df5be3e2d2c42fefa52bd8bd455c51756758da"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "75f6ca1c4dc3b3ae5dc1a1a433753957a9340e83"
+  revision = "103e80beee56cb87c2c4683ba6ff8ea731601f13"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -33,7 +33,6 @@ readonly E2E_TEST_NAMESPACE=e2etest
 # Helper functions.
 
 function knative_setup() {
-  start_latest_knative_serving || return 1
   start_latest_knative_eventing || return 1
 
   header "Standing up Knative Eventing Sources"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -33,6 +33,7 @@ readonly E2E_TEST_NAMESPACE=e2etest
 # Helper functions.
 
 function knative_setup() {
+  start_latest_knative_serving || return 1
   start_latest_knative_eventing || return 1
 
   header "Standing up Knative Eventing Sources"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -93,7 +93,8 @@ function dump_extra_cluster_state() {
 
 # Script entry point.
 
-initialize $@
+# Skip installing istio as an add-on
+initialize $@ --skip-istio-addon
 
 go_test_e2e ./test/e2e || fail_test
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -94,8 +94,7 @@ function dump_extra_cluster_state() {
 
 # Script entry point.
 
-# Skip installing istio as an add-on
-initialize $@ --skip-istio-addon
+initialize $@
 
 go_test_e2e ./test/e2e || fail_test
 

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -172,7 +172,7 @@ This is a helper script for Knative E2E test scripts. To use it:
    will immediately start the tests against the cluster currently configured for
    `kubectl`.
 
-1. By default Istio is installed on the cluster via Addon, using `--skip-istio` if
+1. By default Istio is installed on the cluster via Addon, use `--skip-istio-addon` if
    you choose not to have it preinstalled.
 
 1. You can force running the tests against a specific GKE cluster version by using

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -189,6 +189,7 @@ function create_test_cluster() {
   local gcloud_project="${GCP_PROJECT}"
   [[ -z "${gcloud_project}" ]] && gcloud_project="$(gcloud config get-value project)"
   echo "gcloud project is ${gcloud_project}"
+  echo "gcloud user is $(gcloud config get-value core/account)"
   (( IS_BOSKOS )) && echo "Using boskos for the test cluster"
   [[ -n "${GCP_PROJECT}" ]] && echo "GCP project for test cluster is ${GCP_PROJECT}"
   echo "Test script is ${E2E_SCRIPT}"
@@ -349,7 +350,7 @@ function fail_test() {
 RUN_TESTS=0
 EMIT_METRICS=0
 SKIP_KNATIVE_SETUP=0
-SKIP_ISTIO=0
+SKIP_ISTIO_ADDON=0
 GCP_PROJECT=""
 E2E_SCRIPT=""
 E2E_CLUSTER_VERSION=""
@@ -385,7 +386,7 @@ function initialize() {
       --run-tests) RUN_TESTS=1 ;;
       --emit-metrics) EMIT_METRICS=1 ;;
       --skip-knative-setup) SKIP_KNATIVE_SETUP=1 ;;
-      --skip-istio) SKIP_ISTIO=1 ;;
+      --skip-istio-addon) SKIP_ISTIO_ADDON=1 ;;
       *)
         [[ $# -ge 2 ]] || abort "missing parameter after $1"
         shift
@@ -415,7 +416,7 @@ function initialize() {
   is_protected_gcr ${KO_DOCKER_REPO} && \
     abort "\$KO_DOCKER_REPO set to ${KO_DOCKER_REPO}, which is forbidden"
 
-  (( SKIP_ISTIO )) || GKE_ADDONS="--addons=Istio"
+  (( SKIP_ISTIO_ADDON )) || GKE_ADDONS="--addons=Istio"
 
   readonly RUN_TESTS
   readonly EMIT_METRICS

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -22,14 +22,6 @@
 readonly SERVING_GKE_VERSION=gke-latest
 readonly SERVING_GKE_IMAGE=cos
 
-# Public latest stable nightly images and yaml files.
-readonly KNATIVE_BASE_YAML_SOURCE=https://storage.googleapis.com/knative-nightly/@/latest
-readonly KNATIVE_ISTIO_CRD_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio-crds.yaml
-readonly KNATIVE_ISTIO_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio.yaml
-readonly KNATIVE_SERVING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/serving}/serving.yaml
-readonly KNATIVE_BUILD_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/build}/build.yaml
-readonly KNATIVE_EVENTING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/eventing}/release.yaml
-
 # Conveniently set GOPATH if unset
 if [[ -z "${GOPATH:-}" ]]; then
   export GOPATH="$(go env GOPATH)"
@@ -133,7 +125,7 @@ function wait_until_pods_running() {
         [[ ${status[0]} -lt 1 ]] && all_ready=0 && break
         [[ ${status[1]} -lt 1 ]] && all_ready=0 && break
         [[ ${status[0]} -ne ${status[1]} ]] && all_ready=0 && break
-      done <<< $(echo "${pods}" | grep -v Completed)
+      done <<< "$(echo "${pods}" | grep -v Completed)"
       if (( all_ready )); then
         echo -e "\nAll pods are up:\n${pods}"
         return 0
@@ -450,8 +442,27 @@ function get_canonical_path() {
   echo "$(cd ${path%/*} && echo $PWD/${path##*/})"
 }
 
+# Return the base url we use to build the actual knative yaml sources.
+function get_knative_base_yaml_source() {
+  local knative_base_yaml_source="https://storage.googleapis.com/knative-nightly/@/latest"
+  local branch_name="$(git rev-parse --abbrev-ref HEAD)"
+  # If it's a release branch, we should have a different knative_base_yaml_source.
+  if [[ $branch_name =~ ^release-[0-9\.]+$ ]]; then
+    # Get the latest tag name for the current branch, which is likely formatted as v0.5.0
+    local tag_name="$(git describe --tags)"
+    knative_base_yaml_source="https://storage.googleapis.com/knative-releases/@/previous/${tag_name}"
+  fi
+  echo "${knative_base_yaml_source}"
+}
+
 # Initializations that depend on previous functions.
 # These MUST come last.
 
 readonly _TEST_INFRA_SCRIPTS_DIR="$(dirname $(get_canonical_path ${BASH_SOURCE[0]}))"
 readonly REPO_NAME_FORMATTED="Knative $(capitalize ${REPO_NAME//-/})"
+
+# Public latest nightly or release yaml files.
+readonly KNATIVE_BASE_YAML_SOURCE="$(get_knative_base_yaml_source)"
+readonly KNATIVE_SERVING_RELEASE="${KNATIVE_BASE_YAML_SOURCE/@/serving}/serving.yaml"
+readonly KNATIVE_BUILD_RELEASE="${KNATIVE_BASE_YAML_SOURCE/@/build}/build.yaml"
+readonly KNATIVE_EVENTING_RELEASE="${KNATIVE_BASE_YAML_SOURCE/@/eventing}/release.yaml"


### PR DESCRIPTION
## Proposed Changes
- Update test infra so that we can correctly install the Eventing release with the corresponding version, as per https://github.com/knative/test-infra/issues/721

Note this change is needed to make sure our CI flow for 0.6 release  is not broken.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```