### PR TITLE
golang format tools

### DIFF
--- a/contrib/gcppubsub/cmd/receive_adapter/main.go
+++ b/contrib/gcppubsub/cmd/receive_adapter/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	"github.com/kelseyhightower/envconfig"
-	"github.com/knative/eventing-sources/contrib/gcppubsub/pkg/adapter"
 	"log"
+
+	"github.com/kelseyhightower/envconfig"
+	gcppubsub "github.com/knative/eventing-sources/contrib/gcppubsub/pkg/adapter"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/contrib/gcppubsub/pkg/adapter/adapter.go
+++ b/contrib/gcppubsub/pkg/adapter/adapter.go
@@ -18,7 +18,8 @@ package gcppubsub
 
 import (
 	"fmt"
-	"github.com/cloudevents/sdk-go"
+
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/knative/eventing-sources/pkg/kncloudevents"
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"

--- a/contrib/gcppubsub/pkg/reconciler/gcppubsubsource_test.go
+++ b/contrib/gcppubsub/pkg/reconciler/gcppubsubsource_test.go
@@ -29,7 +29,7 @@ import (
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	eventingsourcesv1alpha1 "github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/contrib/kafka/pkg/reconciler/kafkasource_test.go
+++ b/contrib/kafka/pkg/reconciler/kafkasource_test.go
@@ -30,7 +30,7 @@ import (
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	eventingsourcesv1alpha1 "github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/reconciler/eventtype/eventtype.go
+++ b/pkg/reconciler/eventtype/eventtype.go
@@ -19,6 +19,7 @@ package eventtype
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/equality"
 
 	"github.com/knative/eventing-sources/pkg/reconciler/eventtype/resources"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
