### PR TITLE
golang format tools

### DIFF
--- a/contrib/camel/pkg/install/install.go
+++ b/contrib/camel/pkg/install/install.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/contrib/camel/pkg/reconciler/camelsource.go
+++ b/contrib/camel/pkg/reconciler/camelsource.go
@@ -143,10 +143,10 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) error
 func (r *reconciler) reconcileIntegration(ctx context.Context, source *v1alpha1.CamelSource, deprecatedIntegrationContext string, sinkURI string) (*camelv1alpha1.Integration, error) {
 	logger := logging.FromContext(ctx)
 	args := &resources.CamelArguments{
-		Name:      source.Name,
-		Namespace: source.Namespace,
-		Source:    source.Spec.Source,
-		Sink:      sinkURI,
+		Name:                         source.Name,
+		Namespace:                    source.Namespace,
+		Source:                       source.Spec.Source,
+		Sink:                         sinkURI,
 		DeprecatedIntegrationContext: deprecatedIntegrationContext,
 		DeprecatedServiceAccountName: source.Spec.DeprecatedServiceAccountName,
 	}

--- a/contrib/camel/pkg/reconciler/camelsource_test.go
+++ b/contrib/camel/pkg/reconciler/camelsource_test.go
@@ -27,7 +27,7 @@ import (
 	controllertesting "github.com/knative/eventing-sources/pkg/controller/testing"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"go.uber.org/zap"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/contrib/camel/pkg/reconciler/resources/integration_test.go
+++ b/contrib/camel/pkg/reconciler/resources/integration_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package resources
 
 import (
-	"github.com/knative/eventing-sources/contrib/camel/pkg/apis/sources/v1alpha1"
 	"testing"
+
+	"github.com/knative/eventing-sources/contrib/camel/pkg/apis/sources/v1alpha1"
 
 	camelv1alpha1 "github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	"github.com/google/go-cmp/cmp"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
