### PR TITLE
golang format tools

### DIFF
--- a/contrib/gcppubsub/cmd/receive_adapter/main.go
+++ b/contrib/gcppubsub/cmd/receive_adapter/main.go
@@ -21,7 +21,7 @@ import (
 	"log"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/knative/eventing-sources/contrib/gcppubsub/pkg/adapter"
+	gcppubsub "github.com/knative/eventing-sources/contrib/gcppubsub/pkg/adapter"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
